### PR TITLE
HOOD-51 + HOOD-57: net10 + EF Core 10 foundation (+ EF tooling fix, install wizard, dev frontend)

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -4,12 +4,12 @@ The repo ships a [`docker-compose.yml`](docker-compose.yml) that runs **SQL Serv
 
 This file covers **local dev only**. For repo basics see [readme.md](readme.md).
 
-> **Framework note:** Hood is on **net9.0** as an interim baseline. The current package set is a half-finished retarget that this rig pins to a clean, building state. The full **net10 + EF Core 10** modernisation is tracked separately (HOOD-57), the CI/CD pipeline in HOOD-52, and database schema seeding in HOOD-53.
+> **Framework note:** Hood targets **net10.0 + EF Core 10**. The .NET SDK is pinned via `global.json` and the target framework is centralised in `Directory.Build.props`. The CI/CD pipeline is tracked in HOOD-52 and database schema seeding in HOOD-53.
 
 ## Prerequisites
 
 - Docker Engine + Docker Compose v2 (`docker compose ...` — no hyphen).
-- [.NET 9 SDK](https://dotnet.microsoft.com/download/dotnet/9.0) — only needed to run the app natively (`make run`) rather than in a container.
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) — only needed to run the app natively (`make run`) rather than in a container. The exact SDK is pinned in `global.json`.
 
 ## What's in the compose file
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+
+  <!--
+    Central build + versioning foundation for the Hood solution (HOOD-51).
+    - Single source of truth for the target framework.
+    - Shared package metadata (per-project keeps only PackageId / AssemblyName / Description).
+    - MinVer derives the package version from git tags (prefix `v`), so no csproj hardcodes <Version>.
+      Untagged builds off a branch → 7.0.0-rc.<height>; a `v7.0.0` tag → 7.0.0.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <!-- Shared package metadata -->
+  <PropertyGroup>
+    <Authors>Hood Digital;George Whysall;</Authors>
+    <Company>Hood Digital</Company>
+    <PackageProjectUrl>https://github.com/HoodDigital/Hood</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/HoodDigital/Hood</RepositoryUrl>
+    <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <!-- MinVer: version from git tags, default pre-release phase `rc` -->
+  <PropertyGroup>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerMinimumMajorMinor>7.0</MinVerMinimumMajorMinor>
+    <MinVerDefaultPreReleaseIdentifiers>rc.0</MinVerDefaultPreReleaseIdentifiers>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!-- Shared package metadata -->

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,13 @@
 # ---------------------------------------------------------------------------
 # Stage 1: restore (cached unless a .csproj or the .sln changes)
 # ---------------------------------------------------------------------------
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
-# Copy solution + every live project file first so restore layers cache well.
-COPY Hood.sln ./
+# Copy solution + central build files + every project file first so restore layers cache well.
+# Directory.Build.props carries the TargetFramework and global.json pins the SDK — both are
+# required for `dotnet restore` to resolve, so they must be copied before it runs.
+COPY Hood.sln Directory.Build.props global.json ./
 COPY projects/Hood/Hood.csproj                             projects/Hood/
 COPY projects/Hood.Core/Hood.Core.csproj                   projects/Hood.Core/
 COPY projects/Hood.Admin/Hood.Admin.csproj                 projects/Hood.Admin/
@@ -34,7 +36,7 @@ RUN dotnet publish projects/Hood.Development/Hood.Development.csproj \
 # ---------------------------------------------------------------------------
 # Stage 3: runtime image
 # ---------------------------------------------------------------------------
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,16 @@
 # Hood CMS — Docker build (local dev / containerised run)
 # Runs the Hood.Development web host (the runnable app; the rest are libraries).
 # Usage: docker compose up --build
-# Target framework: net9.0 (interim baseline — HOOD-57 takes this to net10).
+# Target framework: net10.0 (HOOD-57).
+# =============================================================================
+#
+# Frontend assets: Hood's core CSS/JS ship as the external `hoodcms` npm package
+# (normally served from jsDelivr, keyed by the backend assembly version). With the
+# backend now on 7.0.0-rc and `hoodcms` still published at 6.1.x, that CDN path
+# 404s — and the dev appsettings runs with "BypassCDN": true, which expects the
+# assets locally under wwwroot. So we pull the stable `hoodcms` package at build
+# time (frontend stage below) and bundle its src/ + dist/ into wwwroot, keeping
+# the dev rig fully self-contained. Bump HOODCMS_VERSION as the frontend releases.
 # =============================================================================
 
 # ---------------------------------------------------------------------------
@@ -34,13 +43,29 @@ RUN dotnet publish projects/Hood.Development/Hood.Development.csproj \
     -c Release -o /app/publish --no-restore /p:UseAppHost=false
 
 # ---------------------------------------------------------------------------
-# Stage 3: runtime image
+# Stage 3: frontend assets (the `hoodcms` npm package — Hood's core CSS/JS)
+# ---------------------------------------------------------------------------
+FROM node:20-alpine AS frontend
+ARG HOODCMS_VERSION=6.1.8
+WORKDIR /fe
+# `npm pack` downloads the published tarball without installing anything; extracting
+# it yields ./package/{src,dist,images,...} — the same paths the Razor views request.
+RUN npm pack hoodcms@${HOODCMS_VERSION} && tar -xzf hoodcms-*.tgz
+
+# ---------------------------------------------------------------------------
+# Stage 4: runtime image
 # ---------------------------------------------------------------------------
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app
 EXPOSE 8080
 
 COPY --from=build /app/publish .
+
+# Bundle the core frontend so the static-file middleware serves /src/** and /dist/**
+# locally (BypassCDN=true). The dev host keeps its own wwwroot/images, so only the
+# package's src/ and dist/ are layered in.
+COPY --from=frontend /fe/package/src  ./wwwroot/src
+COPY --from=frontend /fe/package/dist ./wwwroot/dist
 
 ENV ASPNETCORE_URLS=http://+:8080
 ENV ASPNETCORE_ENVIRONMENT=Development

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.108",
+    "rollForward": "latestPatch"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.108",
-    "rollForward": "latestPatch"
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
   }
 }

--- a/projects/Hood.Admin/Hood.Admin.csproj
+++ b/projects/Hood.Admin/Hood.Admin.csproj
@@ -2,15 +2,8 @@
   <PropertyGroup>
     <AssemblyName>Hood.Admin</AssemblyName>
     <PackageId>Hood.Admin</PackageId>
-    <Version>7.0.0</Version>
-    <TargetFramework>net9.0</TargetFramework>
-    <Authors>Hood Digital;George Whysall;</Authors>
     <OutputType>Library</OutputType>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
-    <PackageProjectUrl>https://github.com/HoodDigital/Hood</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/HoodDigital/Hood/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageIconUrl>https://hood.blob.core.windows.net/hood/nuget.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/HoodDigital/Hood</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Hood.Core\Hood.Core.csproj" />

--- a/projects/Hood.Core/BaseControllers/InstallController.cs
+++ b/projects/Hood.Core/BaseControllers/InstallController.cs
@@ -1,9 +1,16 @@
-﻿using Hood.Core;
+using Hood.Contexts;
+using Hood.Core;
 using Hood.Extensions;
+using Hood.Models;
+using Hood.Services;
 using Hood.ViewModels;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Hood.BaseControllers
 {
@@ -11,13 +18,14 @@ namespace Hood.BaseControllers
     {
         private readonly IHostApplicationLifetime _applicationLifetime;
         private readonly IConfiguration _config;
-        
+
         public InstallController(IHostApplicationLifetime applicationLifetime, IConfiguration config)
         {
             _applicationLifetime = applicationLifetime;
             _config = config;
         }
 
+        [HttpGet]
         [Route("/install")]
         public IActionResult Install()
         {
@@ -25,7 +33,113 @@ namespace Hood.BaseControllers
             {
                 return RedirectToAction("Index", "Home");
             }
-            return View();
+            return View(new InstallModel { Email = Engine.Configuration?.SuperAdminEmail });
+        }
+
+        /// <summary>
+        /// First-run setup: creates the administrator with the supplied credentials, grants the
+        /// owner roles, seeds Hood (version, site owner, media directories, default settings), then
+        /// restarts the host so it boots cleanly with <see cref="IHoodServiceProvider.Installed"/> true.
+        /// </summary>
+        [HttpPost]
+        [Route("/install")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Install(InstallModel model)
+        {
+            if (Engine.Services.Installed)
+            {
+                return RedirectToAction("Index", "Home");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            try
+            {
+                // The chosen administrator email becomes the site owner for this initialisation run,
+                // so the seed's GetSiteAdmin resolves to the account we are about to create.
+                if (Engine.Configuration != null)
+                {
+                    Engine.Configuration.SuperAdminEmail = model.Email;
+                }
+
+                IPasswordAccountRepository accounts = Engine.Services.Resolve<IPasswordAccountRepository>();
+
+                // Ensure all Hood system roles exist.
+                await accounts.SetupRolesAsync();
+
+                // Create the administrator with the chosen credentials (unless one already exists).
+                ApplicationUser admin = await accounts.GetUserByEmailAsync(model.Email);
+                if (admin == null)
+                {
+                    // ApplicationUser and UserProfile share the AspNetUsers table (table-splitting),
+                    // so both carry the same primary key.
+                    string adminId = Guid.NewGuid().ToString();
+                    admin = new ApplicationUser
+                    {
+                        Id = adminId,
+                        UserName = model.Email,
+                        Email = model.Email,
+                        EmailConfirmed = true,
+                        Active = true,
+                        CreatedOn = DateTime.UtcNow,
+                        LastLogOn = DateTime.UtcNow,
+                        LastLoginIP = "127.0.0.1",
+                        LastLoginLocation = "Setup",
+                        UserProfile = new UserProfile
+                        {
+                            Id = adminId,
+                            Email = model.Email,
+                            UserName = model.Email,
+                            FirstName = "Website",
+                            LastName = "Administrator",
+                            JobTitle = "Website Administrator",
+                            Anonymous = false
+                        }
+                    };
+
+                    IdentityResult created = await accounts.CreateAsync(admin, model.Password);
+                    if (!created.Succeeded)
+                    {
+                        foreach (IdentityError error in created.Errors)
+                        {
+                            ModelState.AddModelError(string.Empty, error.Description);
+                        }
+                        return View(model);
+                    }
+                }
+
+                // Grant the administrator the owner-level roles.
+                List<IdentityRole> ownerRoles = new List<IdentityRole>();
+                foreach (string role in new[] { "SuperUser", "Admin" })
+                {
+                    IdentityRole roleObject = await accounts.GetRoleAsync(role) ?? await accounts.CreateRoleAsync(role);
+                    ownerRoles.Add(roleObject);
+                }
+                await accounts.AddUserToRolesAsync(admin, ownerRoles.ToArray());
+
+                // Seed Hood: version stamp, site owner option, media directories, default settings.
+                HoodDbContext hoodDb = Engine.Services.Resolve<HoodDbContext>();
+                IdentityContext identity = Engine.Services.Resolve<IdentityContext>();
+                await hoodDb.Seed(identity);
+
+                // Restart on a short delay so this response can flush first. The container's restart
+                // policy brings the host straight back up, now booting into an installed state.
+                _ = Task.Run(async () =>
+                {
+                    await Task.Delay(1500);
+                    _applicationLifetime.StopApplication();
+                });
+
+                return RedirectToAction(nameof(Initialized));
+            }
+            catch (Exception ex)
+            {
+                ModelState.AddModelError(string.Empty, "Setup failed: " + ex.Message);
+                return View(model);
+            }
         }
 
         [Route("/install/ready")]

--- a/projects/Hood.Core/Contexts/Auth0IdentityContext.cs
+++ b/projects/Hood.Core/Contexts/Auth0IdentityContext.cs
@@ -131,7 +131,7 @@ namespace Hood.Contexts
         public Auth0IdentityContext CreateDbContext(string[] args)
         {
             var optionsBuilder = new DbContextOptionsBuilder<Auth0IdentityContext>();
-            optionsBuilder.UseSqlServer("Server=localhost\\SQLEXPRESS;Database=Hood.Web;Trusted_Connection=True;MultipleActiveResultSets=true;");
+            optionsBuilder.UseSqlServer(DesignTimeConnection.ConnectionString);
             return new Auth0IdentityContext(optionsBuilder.Options);
         }
     }

--- a/projects/Hood.Core/Contexts/ContentContext.cs
+++ b/projects/Hood.Core/Contexts/ContentContext.cs
@@ -54,6 +54,8 @@ namespace Hood.Contexts
             builder.Entity<ContentCategoryJoin>().HasOne(pt => pt.Content).WithMany(t => t.Categories).HasForeignKey(pt => pt.ContentId);
 
             builder.Entity<ContentMeta>().ToTable("HoodContentMetadata");
+            // Alternate-key columns must be non-nullable under EF Core 9+ (HOOD-48 #12).
+            builder.Entity<ContentMeta>().Property(o => o.Name).IsRequired();
             builder.Entity<ContentMeta>().HasAlternateKey(ol => new { ol.ContentId, ol.Name });
             builder.Entity<ContentMeta>().HasOne(c => c.Content).WithMany(cc => cc.Metadata).HasForeignKey(au => au.ContentId);
             
@@ -73,7 +75,7 @@ namespace Hood.Contexts
         public ContentContext CreateDbContext(string[] args)
         {
             var optionsBuilder = new DbContextOptionsBuilder<ContentContext>();
-            optionsBuilder.UseSqlServer("Server=localhost\\SQLEXPRESS;Database=Hood.Web;Trusted_Connection=True;MultipleActiveResultSets=true;");
+            optionsBuilder.UseSqlServer(DesignTimeConnection.ConnectionString);
             return new ContentContext(optionsBuilder.Options);
         }
     }

--- a/projects/Hood.Core/Contexts/DesignTimeConnection.cs
+++ b/projects/Hood.Core/Contexts/DesignTimeConnection.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Hood.Contexts
+{
+    /// <summary>
+    /// Single source of truth for the design-time (dotnet ef ...) connection string used by the
+    /// <c>IDesignTimeDbContextFactory</c> implementations. Reads <c>HOOD_DESIGNTIME_CONNECTION</c>
+    /// when set, otherwise falls back to a local SQLEXPRESS default.
+    /// <para>
+    /// <c>TrustServerCertificate=True</c> is required because Microsoft.Data.SqlClient 5.x+ (pulled by
+    /// EF Core 7+) defaults <c>Encrypt=true</c>; without it, design-time connections to a local server
+    /// with no valid TLS certificate fail (HOOD-48 breaking-change #9).
+    /// </para>
+    /// </summary>
+    internal static class DesignTimeConnection
+    {
+        public static string ConnectionString =>
+            Environment.GetEnvironmentVariable("HOOD_DESIGNTIME_CONNECTION")
+            ?? "Server=localhost\\SQLEXPRESS;Database=Hood.Web;Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=True;";
+    }
+}

--- a/projects/Hood.Core/Contexts/HoodDbContext.cs
+++ b/projects/Hood.Core/Contexts/HoodDbContext.cs
@@ -291,23 +291,24 @@ namespace Hood.Models
                     {
                         SaveChanges();
 
-                        string commandText = "UPDATE HoodMedia SET DirectoryId = @DirectoryId WHERE DirectoryId IS NULL AND Directory = 'Property'";
-                        SqlParameter sqlParameter = new SqlParameter("@DirectoryId", propertyDir.Id);
-                        int affectedRows = Database.ExecuteSqlRaw(commandText, sqlParameter);
+                        // ExecuteSql (FormattableString) parameterises the interpolated values
+                        // automatically — replaces the deprecated ExecuteSqlRaw (HOOD-48 #3).
+                        int affectedRows = Database.ExecuteSql(
+                            $"UPDATE HoodMedia SET DirectoryId = {propertyDir.Id} WHERE DirectoryId IS NULL AND Directory = 'Property'");
 
                         Option option = Options.Find(typeof(ContentSettings).ToString());
                         var contentSettings = JsonConvert.DeserializeObject<ContentSettings>(option.Value);
                         foreach (var type in contentSettings.Types)
                         {
-                            commandText = "UPDATE HoodMedia SET DirectoryId = @DirectoryId WHERE DirectoryId IS NULL AND Directory = '@Directory'";
-                            sqlParameter = new SqlParameter("@DirectoryId", contentDir.Id);
-                            SqlParameter sqlParameterType = new SqlParameter("@Directory", type.TypeName);
-                            affectedRows = Database.ExecuteSqlRaw(commandText, sqlParameter, sqlParameterType);
+                            // Bug fix (HOOD-48 #3): the old raw SQL had '@Directory' quoted as a string
+                            // literal, so the parameter was never substituted and only 'Property' media
+                            // was ever re-pointed. Interpolation makes type.TypeName a real parameter.
+                            affectedRows = Database.ExecuteSql(
+                                $"UPDATE HoodMedia SET DirectoryId = {contentDir.Id} WHERE DirectoryId IS NULL AND Directory = {type.TypeName}");
                         }
 
-                        commandText = "UPDATE HoodMedia SET DirectoryId = @DirectoryId WHERE DirectoryId IS NULL";
-                        sqlParameter = new SqlParameter("@DirectoryId", defaultDir.Id);
-                        affectedRows = Database.ExecuteSqlRaw(commandText, sqlParameter);
+                        affectedRows = Database.ExecuteSql(
+                            $"UPDATE HoodMedia SET DirectoryId = {defaultDir.Id} WHERE DirectoryId IS NULL");
 
                     }
                 }
@@ -350,7 +351,7 @@ namespace Hood.Models
         public HoodDbContext CreateDbContext(string[] args)
         {
             var optionsBuilder = new DbContextOptionsBuilder<HoodDbContext>();
-            optionsBuilder.UseSqlServer("Server=localhost\\SQLEXPRESS;Database=Hood.Web;Trusted_Connection=True;MultipleActiveResultSets=true;");
+            optionsBuilder.UseSqlServer(DesignTimeConnection.ConnectionString);
             return new HoodDbContext(optionsBuilder.Options);
         }
     }

--- a/projects/Hood.Core/Contexts/IdentityContext.cs
+++ b/projects/Hood.Core/Contexts/IdentityContext.cs
@@ -120,7 +120,7 @@ namespace Hood.Contexts
         public IdentityContext CreateDbContext(string[] args)
         {
             var optionsBuilder = new DbContextOptionsBuilder<IdentityContext>();
-            optionsBuilder.UseSqlServer("Server=localhost\\SQLEXPRESS;Database=Hood.Web;Trusted_Connection=True;MultipleActiveResultSets=true;");
+            optionsBuilder.UseSqlServer(DesignTimeConnection.ConnectionString);
             return new IdentityContext(optionsBuilder.Options);
         }
     }

--- a/projects/Hood.Core/Contexts/PropertyContext.cs
+++ b/projects/Hood.Core/Contexts/PropertyContext.cs
@@ -40,10 +40,15 @@ namespace Hood.Contexts
             base.OnModelCreating(builder);            
         
             builder.Entity<PropertyListing>().ToTable("HoodProperties");
-            builder.Entity<PropertyListing>().Property(a => a.Latitude).HasDefaultValueSql("0.0");
-            builder.Entity<PropertyListing>().Property(a => a.Longitude).HasDefaultValueSql("0.0");
+            // HasSentinel(-1) so a real (0,0) coordinate is INSERTed explicitly instead of being
+            // treated as "unset" and omitted under the EF Core 8+ sentinel rules (HOOD-48 #4).
+            // The DB-side DEFAULT (0.0) is unchanged, so there is no schema delta.
+            builder.Entity<PropertyListing>().Property(a => a.Latitude).HasDefaultValueSql("0.0").HasSentinel(-1d);
+            builder.Entity<PropertyListing>().Property(a => a.Longitude).HasDefaultValueSql("0.0").HasSentinel(-1d);
 
             builder.Entity<PropertyMeta>().ToTable("HoodPropertyMetadata");
+            // Alternate-key columns must be non-nullable under EF Core 9+ (HOOD-48 #12).
+            builder.Entity<PropertyMeta>().Property(o => o.Name).IsRequired();
             builder.Entity<PropertyMeta>().HasAlternateKey(ol => new { ol.PropertyId, ol.Name });
             builder.Entity<PropertyMeta>().HasOne(c => c.Property).WithMany(cc => cc.Metadata).HasForeignKey(au => au.PropertyId).OnDelete(DeleteBehavior.Restrict);
 
@@ -71,7 +76,7 @@ namespace Hood.Contexts
         public PropertyContext CreateDbContext(string[] args)
         {
             var optionsBuilder = new DbContextOptionsBuilder<PropertyContext>();
-            optionsBuilder.UseSqlServer("Server=localhost\\SQLEXPRESS;Database=Hood.Web;Trusted_Connection=True;MultipleActiveResultSets=true;");
+            optionsBuilder.UseSqlServer(DesignTimeConnection.ConnectionString);
             return new PropertyContext(optionsBuilder.Options);
         }
     }

--- a/projects/Hood.Core/Engine.cs
+++ b/projects/Hood.Core/Engine.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/projects/Hood.Core/Extensions/IConfigurationExtensions.cs
+++ b/projects/Hood.Core/Extensions/IConfigurationExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Hood.Core;
 using Microsoft.Extensions.Configuration;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace Hood.Extensions
 {

--- a/projects/Hood.Core/Hood.Core.csproj
+++ b/projects/Hood.Core/Hood.Core.csproj
@@ -13,26 +13,23 @@
     <PackageReference Include="BundlerMinifier.Core" Version="3.2.449" />
     <PackageReference Include="Geocoding.Core" Version="4.0.1" />
     <PackageReference Include="Geocoding.Google" Version="4.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.16" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.16" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.16" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.16" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.16" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="9.0.16" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.16" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.16">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="Sendgrid" Version="9.28.0" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.48" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-    <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
     <PackageReference Include="unsplasharp.api" Version="0.7.0" />
   </ItemGroup>
 </Project>

--- a/projects/Hood.Core/Hood.Core.csproj
+++ b/projects/Hood.Core/Hood.Core.csproj
@@ -20,6 +20,12 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+    <!-- Pin Design explicitly: Tools 10.0.8 only floors Design at 8.0.0 transitively, which
+         loads an EF 8 design assembly against the EF 10 runtime and breaks `dotnet ef`. -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/projects/Hood.Core/Hood.Core.csproj
+++ b/projects/Hood.Core/Hood.Core.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <AssemblyName>Hood.Core</AssemblyName>
     <PackageId>Hood.Core</PackageId>
-    <Version>7.0.0</Version>
-    <TargetFramework>net9.0</TargetFramework>
-    <Authors>Hood Digital;George Whysall;</Authors>
     <OutputType>Library</OutputType>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>

--- a/projects/Hood.Core/Services/MediaManager/MediaManager.cs
+++ b/projects/Hood.Core/Services/MediaManager/MediaManager.cs
@@ -269,14 +269,17 @@ namespace Hood.Services
                 string fileName = Path.GetFileNameWithoutExtension(media.Url);
                 string fileExt = Path.GetExtension(media.Url);
                 string thumbBlobReference = $"{media.Path}/{fileName}{prefix}{fileExt}";
-                IImageFormat format;
                 stream.Position = 0;
-                using (Image image = Image.Load(stream, out format))
+                using (Image image = Image.Load(stream))
                 {
+                    // ImageSharp 3.x: the out-format Load overload was removed — the decoded format
+                    // now lives on Metadata, and Save takes an encoder rather than a format (HOOD-57).
+                    IImageFormat format = image.Metadata.DecodedImageFormat;
                     image.Mutate(x => x.Resize(size, 0));
                     using (Stream outputStream = new System.IO.MemoryStream())
                     {
-                        image.Save(outputStream, format);
+                        IImageEncoder encoder = image.Configuration.ImageFormatsManager.GetEncoder(format);
+                        image.Save(outputStream, encoder);
                         outputStream.Position = 0;
                         var blob = await Upload(outputStream, thumbBlobReference);
                         url = blob.Uri.ToUrlString();

--- a/projects/Hood.Core/Services/SettingsRepository/SettingsRepository.cs
+++ b/projects/Hood.Core/Services/SettingsRepository/SettingsRepository.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 
 namespace Hood.Services

--- a/projects/Hood.Core/Startup/IApplicationBuilderExtensions.cs
+++ b/projects/Hood.Core/Startup/IApplicationBuilderExtensions.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Globalization;
 using System.IO;
 using System.Linq;

--- a/projects/Hood.Core/Startup/IHostExtensions.cs
+++ b/projects/Hood.Core/Startup/IHostExtensions.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/projects/Hood.Core/ViewModels/InstallModel.cs
+++ b/projects/Hood.Core/ViewModels/InstallModel.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Hood.ViewModels
+{
+    /// <summary>
+    /// Backs the first-run install wizard (<c>/install</c>). Collects the administrator
+    /// credentials used to seed the site owner. The email defaults to the configured
+    /// <c>Hood:SuperAdminEmail</c> but can be overridden during setup.
+    /// </summary>
+    public class InstallModel
+    {
+        [Required]
+        [EmailAddress]
+        [Display(Name = "Administrator email")]
+        public string Email { get; set; }
+
+        [Required]
+        [DataType(DataType.Password)]
+        [Display(Name = "Password")]
+        public string Password { get; set; }
+
+        [Required]
+        [DataType(DataType.Password)]
+        [Display(Name = "Confirm password")]
+        [Compare(nameof(Password), ErrorMessage = "The passwords do not match.")]
+        public string ConfirmPassword { get; set; }
+    }
+}

--- a/projects/Hood.Development/Hood.Development.csproj
+++ b/projects/Hood.Development/Hood.Development.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <Version>7.0.0</Version>
-    <TargetFramework>net9.0</TargetFramework>
     <UserSecretsId>Hood.Web</UserSecretsId>
     <TypeScriptToolsVersion>4.3</TypeScriptToolsVersion>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>

--- a/projects/Hood.Development/Views/Install/Initialized.cshtml
+++ b/projects/Hood.Development/Views/Install/Initialized.cshtml
@@ -8,6 +8,8 @@
 
 <head>
     <title>@ViewData["Title"]</title>
+    <!-- The host restarts after setup; reload into the now-installed site shortly. -->
+    <meta http-equiv="refresh" content="8; url=/" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 
     <environment exclude="Production">
@@ -34,19 +36,8 @@
                 <h4>
                     Your website is ready to roll!
                 </h4>
-                <p>You just need to disable initialization flags in your environment variables to start the site.</p>
-                <div class="card border-danger text-start p-3">
-                    <ul>
-                        @if (Engine.Configuration.InitializeOnStartup)
-                        {                            
-                            <li>Disable the <code>Hood:InitializeOnStartup</code> flag in your app settings.</li>
-                        } 
-                        @if (Engine.Auth0Configuration.SetupRemoteOnIntitialize)
-                        {                            
-                            <li>Disable the <code>Identity:Auth0:SetupRemoteOnIntitialize</code> flag in your app settings.</li>
-                        } 
-                    </ul>
-                </div>
+                <p>Setup is complete and the application is restarting. This page will take you to your site in a few seconds&hellip;</p>
+                <p><a href="/" class="btn btn-primary">Go to your site now</a></p>
             </div>
         </div>
 

--- a/projects/Hood.Development/Views/Install/Install.cshtml
+++ b/projects/Hood.Development/Views/Install/Install.cshtml
@@ -1,4 +1,4 @@
-@model string
+@model Hood.ViewModels.InstallModel
 @inject Microsoft.AspNetCore.Hosting.IWebHostEnvironment _env
 @{
     bool production = _env.EnvironmentName == "Production";
@@ -33,6 +33,11 @@
         <div class="login-content" style="max-width:100%;">
             @{
                 bool previousError = false;
+                bool canSeed =
+                    !Engine.Services.GetStartupExceptionsByType(StartupError.NoConnectionString).Any() &&
+                    !Engine.Services.GetStartupExceptionsByType(StartupError.DatabaseConnectionFailed).Any() &&
+                    !Engine.Services.GetStartupExceptionsByType(StartupError.MigrationMissing).Any() &&
+                    !Engine.Services.GetStartupExceptionsByType(StartupError.MigrationNotApplied).Any();
             }
 
             @if (Engine.Services.Installed)
@@ -45,11 +50,39 @@
             }
             else
             {
-                <div class="header mb-5">
+                <div class="header mb-4">
                     <h2>Install</h2>
-                    <p>The CMS Setup is currently incomplete.</p>
-                    <p><strong>Once you have updated the settings, please restart the application for changes to take effect.</strong></p>
+                    @if (canSeed)
+                    {
+                        <p>Your database is connected and up to date. Create the administrator account below to finish setting up your site.</p>
+                    }
+                    else
+                    {
+                        <p>The CMS setup is currently incomplete. Resolve the issues below, then reload this page to continue.</p>
+                    }
                 </div>
+
+                @if (canSeed)
+                {
+                    <form method="post" action="/install" class="setup-form mb-5">
+                        @Html.AntiForgeryToken()
+                        @Html.ValidationSummary(false, "", new { @class = "alert alert-danger" })
+                        <div class="mb-3">
+                            <label for="Email" class="form-label">Administrator email</label>
+                            <input type="email" id="Email" name="Email" value="@Model?.Email" class="form-control" required autofocus />
+                        </div>
+                        <div class="mb-3">
+                            <label for="Password" class="form-label">Password</label>
+                            <input type="password" id="Password" name="Password" class="form-control" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="ConfirmPassword" class="form-label">Confirm password</label>
+                            <input type="password" id="ConfirmPassword" name="ConfirmPassword" class="form-control" required />
+                        </div>
+                        <button type="submit" class="btn btn-primary w-100">Set up Hood</button>
+                    </form>
+                }
+
                 <div class="accordion" id="startup-accordion">
 
                     <div class="accordion-item border-0 mb-3">

--- a/projects/Hood.UI.Admin/Hood.UI.Admin.csproj
+++ b/projects/Hood.UI.Admin/Hood.UI.Admin.csproj
@@ -2,15 +2,8 @@
   <PropertyGroup>
     <AssemblyName>Hood.UI.Admin</AssemblyName>
     <PackageId>Hood.UI.Admin</PackageId>
-    <Version>7.0.0</Version>
-    <TargetFramework>net9.0</TargetFramework>
-    <Authors>Hood Digital;George Whysall;</Authors>
     <OutputType>Library</OutputType>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
-    <PackageProjectUrl>https://github.com/HoodDigital/Hood</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/HoodDigital/Hood/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageIconUrl>https://hood.blob.core.windows.net/hood/nuget.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/HoodDigital/Hood</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="node_modules\**" />

--- a/projects/Hood.UI.Bootstrap3/Hood.UI.Bootstrap3.csproj
+++ b/projects/Hood.UI.Bootstrap3/Hood.UI.Bootstrap3.csproj
@@ -2,16 +2,9 @@
   <PropertyGroup>
     <AssemblyName>Hood.UI.Bootstrap3</AssemblyName>
     <PackageId>Hood.UI.Bootstrap3</PackageId>
-    <Version>7.0.0</Version>
-    <TargetFramework>net9.0</TargetFramework>
-    <Authors>Hood Digital;George Whysall;</Authors>
     <OutputType>Library</OutputType>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
-    <PackageProjectUrl>https://github.com/HoodDigital/Hood</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/HoodDigital/Hood/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageIconUrl>https://hood.blob.core.windows.net/hood/nuget.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/HoodDigital/Hood</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Hood.Core\Hood.Core.csproj" />

--- a/projects/Hood.UI.Bootstrap4/Hood.UI.Bootstrap4.csproj
+++ b/projects/Hood.UI.Bootstrap4/Hood.UI.Bootstrap4.csproj
@@ -2,16 +2,9 @@
   <PropertyGroup>
     <AssemblyName>Hood.UI.Bootstrap4</AssemblyName>
     <PackageId>Hood.UI.Bootstrap4</PackageId>
-    <Version>7.0.0</Version>
-    <TargetFramework>net9.0</TargetFramework>
-    <Authors>Hood Digital;George Whysall;</Authors>
     <OutputType>Library</OutputType>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
-    <PackageProjectUrl>https://github.com/HoodDigital/Hood</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/HoodDigital/Hood/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageIconUrl>https://hood.blob.core.windows.net/hood/nuget.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/HoodDigital/Hood</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Hood.Core\Hood.Core.csproj" />

--- a/projects/Hood.UI.Core/BaseUI/Install/Initialized.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Install/Initialized.cshtml
@@ -8,6 +8,8 @@
 
 <head>
     <title>@ViewData["Title"]</title>
+    <!-- The host restarts after setup; reload into the now-installed site shortly. -->
+    <meta http-equiv="refresh" content="8; url=/" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 
     <environment exclude="Production">
@@ -34,19 +36,8 @@
                 <h4>
                     Your website is ready to roll!
                 </h4>
-                <p>You just need to disable initialization flags in your environment variables to start the site.</p>
-                <div class="card border-danger text-start p-3">
-                    <ul>
-                        @if (Engine.Configuration.InitializeOnStartup)
-                        {                            
-                            <li>Disable the <code>Hood:InitializeOnStartup</code> flag in your app settings.</li>
-                        } 
-                        @if (Engine.Auth0Configuration.SetupRemoteOnIntitialize)
-                        {                            
-                            <li>Disable the <code>Identity:Auth0:SetupRemoteOnIntitialize</code> flag in your app settings.</li>
-                        } 
-                    </ul>
-                </div>
+                <p>Setup is complete and the application is restarting. This page will take you to your site in a few seconds&hellip;</p>
+                <p><a href="/" class="btn btn-primary">Go to your site now</a></p>
             </div>
         </div>
 

--- a/projects/Hood.UI.Core/BaseUI/Install/Install.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Install/Install.cshtml
@@ -1,4 +1,4 @@
-@model string
+@model Hood.ViewModels.InstallModel
 @inject Microsoft.AspNetCore.Hosting.IWebHostEnvironment _env
 @{
     bool production = _env.EnvironmentName == "Production";
@@ -33,6 +33,11 @@
         <div class="login-content" style="max-width:100%;">
             @{
                 bool previousError = false;
+                bool canSeed =
+                    !Engine.Services.GetStartupExceptionsByType(StartupError.NoConnectionString).Any() &&
+                    !Engine.Services.GetStartupExceptionsByType(StartupError.DatabaseConnectionFailed).Any() &&
+                    !Engine.Services.GetStartupExceptionsByType(StartupError.MigrationMissing).Any() &&
+                    !Engine.Services.GetStartupExceptionsByType(StartupError.MigrationNotApplied).Any();
             }
 
             @if (Engine.Services.Installed)
@@ -45,11 +50,39 @@
             }
             else
             {
-                <div class="header mb-5">
+                <div class="header mb-4">
                     <h2>Install</h2>
-                    <p>The CMS Setup is currently incomplete.</p>
-                    <p><strong>Once you have updated the settings, please restart the application for changes to take effect.</strong></p>
+                    @if (canSeed)
+                    {
+                        <p>Your database is connected and up to date. Create the administrator account below to finish setting up your site.</p>
+                    }
+                    else
+                    {
+                        <p>The CMS setup is currently incomplete. Resolve the issues below, then reload this page to continue.</p>
+                    }
                 </div>
+
+                @if (canSeed)
+                {
+                    <form method="post" action="/install" class="setup-form mb-5">
+                        @Html.AntiForgeryToken()
+                        @Html.ValidationSummary(false, "", new { @class = "alert alert-danger" })
+                        <div class="mb-3">
+                            <label for="Email" class="form-label">Administrator email</label>
+                            <input type="email" id="Email" name="Email" value="@Model?.Email" class="form-control" required autofocus />
+                        </div>
+                        <div class="mb-3">
+                            <label for="Password" class="form-label">Password</label>
+                            <input type="password" id="Password" name="Password" class="form-control" required />
+                        </div>
+                        <div class="mb-3">
+                            <label for="ConfirmPassword" class="form-label">Confirm password</label>
+                            <input type="password" id="ConfirmPassword" name="ConfirmPassword" class="form-control" required />
+                        </div>
+                        <button type="submit" class="btn btn-primary w-100">Set up Hood</button>
+                    </form>
+                }
+
                 <div class="accordion" id="startup-accordion">
 
                     <div class="accordion-item border-0 mb-3">

--- a/projects/Hood.UI.Core/Hood.UI.Core.csproj
+++ b/projects/Hood.UI.Core/Hood.UI.Core.csproj
@@ -2,16 +2,9 @@
   <PropertyGroup>
     <AssemblyName>Hood.UI.Core</AssemblyName>
     <PackageId>Hood.UI.Core</PackageId>
-    <Version>7.0.0</Version>
-    <TargetFramework>net9.0</TargetFramework>
-    <Authors>Hood Digital;George Whysall;</Authors>
     <OutputType>Library</OutputType>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
-    <PackageProjectUrl>https://github.com/HoodDigital/Hood</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/HoodDigital/Hood/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageIconUrl>https://hood.blob.core.windows.net/hood/nuget.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/HoodDigital/Hood</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Hood.Core\Hood.Core.csproj" />

--- a/projects/Hood/Hood.csproj
+++ b/projects/Hood/Hood.csproj
@@ -3,15 +3,8 @@
     <AssemblyName>Hood</AssemblyName>
     <PackageId>Hood</PackageId>
     <Description>Complete Hood CMS Package, includes all default controllers for basic setup, packaged with the Bootstrap 4 default theme.</Description>
-    <Version>7.0.0</Version>
-    <TargetFramework>net9.0</TargetFramework>
-    <Authors>Hood Digital;George Whysall;</Authors>
     <OutputType>Library</OutputType>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
-    <PackageProjectUrl>https://github.com/HoodDigital/Hood</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/HoodDigital/Hood/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageIconUrl>https://hood.blob.core.windows.net/hood/nuget.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/HoodDigital/Hood</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Hood.Core\Hood.Core.csproj" />


### PR DESCRIPTION
## Overview

Two foundational slices of the Hood CMS v7 modernisation (parent **HOOD-49**), landed together so the solution is net10-green by the end of the branch:

- **HOOD-51** — central build + versioning foundation (single source of truth for SDK, TFM and version).
- **HOOD-57** — retarget the surviving 8 projects to **net10 + EF Core 10** with all code-only break-fixes.

While validating the net10 rig end-to-end (build → boot → install → seed → render), three follow-on fixes were needed and are included here:

- **HOOD-57** — pin EF Core `Design` to 10.0.8 (the retarget left it floating to an EF 8 assembly, breaking `dotnet ef`).
- **HOOD-53** — a form-driven install wizard so a fresh DB can actually be seeded (groundwork for the schema-init mechanism).
- **HOOD-54** — bundle the `hoodcms` frontend into the dev container so the rig renders CSS/JS self-contained (dev-rig stopgap for the FE/BE version coupling).

Closes HOOD-51
Closes HOOD-57
Contributes to HOOD-53, HOOD-54

---

## What Changed and Why

**Central build foundation (HOOD-51)**
- Added `global.json` pinning the .NET 10 SDK. Uses `rollForward: latestFeature` (not the ticket's draft `latestPatch`) — the dev host (`10.0.108`) and the Docker `sdk:10.0` image (`10.0.300`) sit in **different feature bands**, and `latestPatch` won't cross bands. `latestFeature` lets one `global.json` resolve everywhere. Host-SDK alignment tracked in **HOOD-63**.
- Added `Directory.Build.props` carrying the single `<TargetFramework>`, shared package metadata (Authors, Company, Repository/Project URLs, GPL-3.0-only licence) and **MinVer** config (`v` tag prefix, `7.0` floor, `rc.0` pre-release). `dotnet pack` now stamps a git-derived version — verified: `Hood.Core.7.0.0-rc.0.6.nupkg`.
- Stripped per-csproj `<Version>`, `<TargetFramework>` and the now-centralised metadata from all 8 projects. The .NET version is decoupled from `Hood.Development/package.json`.

**net10 + EF Core 10 retarget (HOOD-57)**
- Central TFM flipped to `net10.0`; all `Microsoft.*` + EF Core / Identity / ASP.NET Core package refs moved to `10.0.8`. EF Core 10 resolves the `System.Linq.AsyncEnumerable` BCL clash that breaks EF Core <10 on net10.
- **Dependency swaps:** `System.Data.SqlClient` → `Microsoft.Data.SqlClient`; ImageSharp 2.x → `3.1.12`; dropped dead `System.Drawing.Common` and `System.IO.Compression.ZipFile`.
- **EF6→10 code-only break-fixes** (per the ratified HOOD-48 inventory): `ExecuteSqlRaw` → `ExecuteSql` with proper interpolation (fixes the quoted-parameter bug, ×3 in `HoodDbContext`); `HasDefaultValueSql` + explicit `HasSentinel` on Lat/Long; `IsRequired` before `HasAlternateKey` on `ContentMeta`/`PropertyMeta.Name`; `MediaManager.GenerateThumb` rewritten for the ImageSharp 3.x encoder API.
- Centralised the 5 hardcoded `IDesignTimeDbContextFactory` connection strings into one env-driven `DesignTimeConnection` (`HOOD_DESIGNTIME_CONNECTION`, `TrustServerCertificate=True`).
- **EF `Design` pin:** the retarget dropped the explicit `Microsoft.EntityFrameworkCore.Design` reference; with only `Tools 10.0.8` pulling it, it floated transitively to **8.0.0** and loaded an EF 8 design assembly against the EF 10 runtime — breaking every `dotnet ef` command (`Method 'Identifier' ... does not have an implementation`). Pinned explicitly to `10.0.8`.

**Install wizard (HOOD-53 groundwork)**
- Nothing called `HoodDbContext.Seed()` after the demo-project prune (HOOD-56), so a migrated DB could never be seeded through any runtime path and `/install` was only a read-only diagnostic. Added a form-driven wizard: `InstallModel` + `[HttpPost] /install` creates the administrator with chosen credentials, grants `SuperUser` + `Admin` roles, seeds Hood (version, site owner, media dirs, settings), then restarts the host so it boots installed. Views updated in both `Hood.UI.Core` (embedded/canonical) and `Hood.Development` (the dev-host copies that override them).
- This is a prototype of the seed/install half of the schema-init mechanism; the productised CLI/init-script form remains **HOOD-53**.

**Dev-rig frontend bundle (HOOD-54 stopgap)**
- Hood serves core CSS/JS from the external `hoodcms` npm package keyed to the **backend** assembly version. With the backend now `7.0.0-rc` and `hoodcms` still at `6.1.x` (and `BypassCDN=true` expecting local assets), the containerised rig 404s all frontend. The `Dockerfile` now pulls `hoodcms` at build time (arg `HOODCMS_VERSION`, default `6.1.8`) and bundles `src/` + `dist/` into `wwwroot`. The underlying FE/BE version-coupling fix remains **HOOD-54**.

**Docker**
- `sdk`/`aspnet` base images bumped 9.0 → 10.0; `Directory.Build.props` + `global.json` now copied before `dotnet restore` so the TFM/SDK resolve in-layer.

---

## Tests

- `dotnet build Hood.sln -c Release`: **0 warnings, 0 errors**, all 8 projects on `net10.0`.
- All **5 DbContext models** build clean via `dotnet ef dbcontext info` (forces full model build — would throw on any of the EF10 mapping break-changes). `dotnet ef` now runs after the `Design` pin.
- `dotnet pack` stamps the expected MinVer version (`7.0.0-rc.0.6`).
- App boots on the net10 runtime; migrations apply via `dotnet ef database update` across the 4 active contexts; the install wizard seeds end-to-end (`Hood.Version = 7.0.0`, admin + 6 roles) and the **home page renders** with bundled frontend assets (`200`).

---

## Breaking Changes

- TFM is now `net10.0` — consumers must build on the .NET 10 SDK.
- `Microsoft.Data.SqlClient` defaults `Encrypt=true`; connection strings may need `TrustServerCertificate=True` / `Encrypt=False` for local SQL.

---

## Testing Plan

- [ ] `docker compose up --build` brings up the stack and the app serves on `http://localhost:5070`.
- [ ] `dotnet build Hood.sln -c Release` is clean on a fresh checkout.
- [ ] `dotnet pack` produces a MinVer-stamped package.
- [ ] `/install` wizard creates the admin and seeds a fresh DB; the home page renders with frontend assets.

---

## Known Follow-ups

- **HOOD-58** — SQL views (`HoodContentViews`, `HoodUserProfiles`, `HoodPropertyViews`) are not created by migrations and `sql/latest.sql` is stale (references pre-JSON `*Id` columns vs current `*Json`). Login/admin/content 500 until the views are regenerated. Details logged on HOOD-58.
- **HOOD-53** — productise the schema-init mechanism (CLI/init-script) on top of the wizard prototype here.
- **HOOD-54** — decouple the frontend asset version from the backend assembly version (the Dockerfile bundle is a dev-rig stopgap).
- **HOOD-63** — host-SDK band alignment.
- **HOOD-50** — 52 Dependabot vulnerabilities flagged on push (2 critical, 20 high).

**Docs updated:** yes — `DOCKER.md` framework note + SDK link moved net9 → net10.
