### PR TITLE
HOOD-65 + HOOD-71 - Standard-Identity login/admin fixes (IAuth0Service DI + reCAPTCHA bypass)

### DIFF
--- a/projects/Hood.Admin/Controllers/UsersController.cs
+++ b/projects/Hood.Admin/Controllers/UsersController.cs
@@ -7,7 +7,9 @@ namespace Hood.Areas.Admin.Controllers
 {
     [Area("Admin")]
     [Authorize(Roles = "SuperUser,Admin")]
-    public class UsersController : Auth0UsersController
+    // Standard ASP.NET Identity is the default backend; this admin controller derives from the
+    // standard base. Auth0 deployments substitute Hood.Admin.BaseControllers.Auth0UsersController.
+    public class UsersController : Hood.Admin.BaseControllers.UsersController
     {
         public UsersController()
             : base()

--- a/projects/Hood.Core/Services/RecaptchaService/RecaptchaService.cs
+++ b/projects/Hood.Core/Services/RecaptchaService/RecaptchaService.cs
@@ -16,8 +16,11 @@ namespace Hood.Services
             {
                 Models.IntegrationSettings settings = Engine.Settings.Integrations;
 
-                if (!Engine.Settings.Integrations.EnableGoogleRecaptcha)
-                    return new RecaptchaResponse() { Success = true };
+                // Only enforce recaptcha when it is fully configured (toggle on AND both keys set).
+                // Otherwise treat the check as passed so login / register / forms aren't blocked —
+                // callers gate on .Passed, so this must set Passed, not just Success.
+                if (!settings.IsGoogleRecaptchaEnabled)
+                    return new RecaptchaResponse() { Success = true, Passed = true };
 
                 if (!request.Form.ContainsKey("g-recaptcha-response")) // error if no reason to do anything, this is to alert developers they are calling it without reason.
                 {

--- a/projects/Hood.Development/Controllers/AccountController.cs
+++ b/projects/Hood.Development/Controllers/AccountController.cs
@@ -2,7 +2,9 @@
 
 namespace Hood.Web.Controllers
 {
-    public class AccountController : Hood.BaseControllers.Auth0AccountController
+    // Standard ASP.NET Identity is the default backend. Use the Auth0 base
+    // (Hood.BaseControllers.Auth0AccountController) only when Auth0 is configured.
+    public class AccountController : Hood.BaseControllers.AccountController
     {
         public AccountController()
             : base()


### PR DESCRIPTION
## Overview

Two one-line "make the default standard-Identity login flow work" fixes, found and verified together while manually testing the net10 rig.

Closes HOOD-65
Closes HOOD-71

---

## What Changed and Why

**HOOD-65 — standard-Identity login/admin 500 (`IAuth0Service` DI)**
The shipped concrete controllers derived from the **Auth0** base controllers, whose constructors eagerly resolve `IAuth0Service` + `IAuth0AccountRepository` — services only registered when Auth0 is configured (`ConfigureAuth0`). On the default standard-Identity deployment those aren't registered, so `/account/login` and the admin `/users` page threw `No service for type 'IAuth0Service'` 500s for every standard consumer (Hood.Admin is the shared admin lib).

Point the shipped controllers at the standard Identity bases:
- `Hood.Development/Controllers/AccountController` → `Hood.BaseControllers.AccountController`
- `Hood.Admin/Controllers/UsersController` → `Hood.Admin.BaseControllers.UsersController`

Auth0 deployments opt in by substituting the `Auth0*` bases, matching the startup branch that only wires Auth0 when `Domain` + `ClientId` are configured.

**HOOD-71 — reCAPTCHA blocked login when not configured**
`RecaptchaService.Validate()` short-circuits when reCAPTCHA is off but returned `Success=true` without setting `Passed` — and callers gate on `.Passed`, so an unconfigured check reported as *failed* and blocked login/register. Now the bypass sets `Passed=true` and keys off `IsGoogleRecaptchaEnabled` (toggle **and** both keys set), so reCAPTCHA is only enforced when fully configured with valid keys.

---

## Tests

- net10 build clean (0 errors).
- Rebuilt the app image on the net10 Docker rig: `/`, `/install`, `/account/login`, `/admin` all 200 (login + admin were 500); installed via the wizard and **logged in as the seeded admin** with reCAPTCHA unconfigured (previously blocked). No `IAuth0Service`/DI errors.

---

## Breaking Changes

- None for standard Identity (the default). Auth0 deployments derive their `AccountController`/`UsersController` from the `Auth0*` bases explicitly — consistent with Auth0 already being opt-in.

---

## Follow-ups filed from the same test session (not in this PR)

- **HOOD-66** standard admin Users area missing role views · **HOOD-67** media upload 500 when storage unset · **HOOD-68** Data Protection keys not persisted across rebuilds · **HOOD-69** EF QuerySplittingBehavior warning · **HOOD-70** new-page 404 on immediate preview.
