### PR TITLE
HOOD-67/68/69/70 - v7 bugfix batch (media, DP keys, split-query, preview cache)

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -20,6 +20,8 @@ This file covers **local dev only**. For repo basics see [readme.md](readme.md).
 
 Host port `14331` avoids clashes with a native SQL Server (`1433`) or other local dev stacks (bma-live uses `14330`). The SA password defaults to `Hood_Dev_Passw0rd!` — fine for throwaway local use; change it for anything exposed.
 
+The app's **Data Protection keys** persist in the `hood-keys` named volume (mounted at `/keys`, set via `Hood__DataProtectionKeyPath`). This keeps antiforgery tokens and auth cookies valid across container rebuilds — without it the key ring resets on every rebuild and you'd hit *"The antiforgery token could not be decrypted"* until you cleared cookies.
+
 ## Quick start
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,9 +49,13 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://+:8080
       - ConnectionStrings__DefaultConnection=Server=sqlserver;Database=Hood.Web;User Id=sa;Password=Hood_Dev_Passw0rd!;TrustServerCertificate=True;MultipleActiveResultSets=True
+      # Persist the Data Protection key ring so antiforgery tokens / auth cookies survive rebuilds.
+      - Hood__DataProtectionKeyPath=/keys
     ports:
       # Host 5070 → container 8080 (bma-live uses 5050; keep Hood distinct).
       - "5070:8080"
+    volumes:
+      - hood-keys:/keys
     depends_on:
       sqlserver:
         condition: service_healthy
@@ -67,4 +71,5 @@ networks:
 
 volumes:
   sqlserver-data:
+  hood-keys:
     driver: local

--- a/projects/Hood.Core/BaseControllers/Admin/MediaController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/MediaController.cs
@@ -314,6 +314,11 @@ namespace Hood.Admin.BaseControllers
         {
             try
             {
+                if (!_media.IsConfigured)
+                {
+                    return new Response("Media storage isn't set up yet. An administrator needs to configure a storage connection string in Settings > Media Settings before files can be uploaded.");
+                }
+
                 if (!directoryId.HasValue)
                 {
                     throw new Exception("You must select a directory to upload to.");

--- a/projects/Hood.Core/Services/ContentRepository/ContentRepository.cs
+++ b/projects/Hood.Core/Services/ContentRepository/ContentRepository.cs
@@ -250,6 +250,7 @@ namespace Hood.Services
             content = await GetContentByIdAsync(content.Id);
             await RefreshMetasAsync(content);
             _eventService.TriggerContentChanged(this);
+            ClearPageCaches();
             return content;
         }
         public async Task<Content> UpdateAsync(Content content)
@@ -259,6 +260,7 @@ namespace Hood.Services
             await _db.SaveChangesAsync();
             _eventService.TriggerContentChanged(this);
             _cache.Add(cacheKey, content, TimeSpan.FromMinutes(60));
+            ClearPageCaches();
             return content;
         }
         public async Task DeleteAsync(int id)
@@ -266,6 +268,22 @@ namespace Hood.Services
             Content content = _db.Content.Where(p => p.Id == id).FirstOrDefault();
             _db.Entry(content).State = EntityState.Deleted;
             await _db.SaveChangesAsync();
+            _cache.Remove(typeof(Content).ToString() + ".Single." + id);
+            _eventService.TriggerContentChanged(this);
+            ClearPageCaches();
+        }
+
+        // The page list that backs the public route constraint (PagesRouteConstraint -> GetPages) is cached
+        // for 60 minutes. Without invalidation, a newly created/edited page isn't routable until the cache
+        // expires (HOOD-70: 404 when previewing a freshly created page). Clear every ".Pages" variant
+        // (base + per-category) on any content mutation so the route resolves immediately.
+        private void ClearPageCaches()
+        {
+            string prefix = typeof(Content).ToString();
+            foreach (string key in _cache.Keys.Keys.Where(k => k.StartsWith(prefix) && k.EndsWith(".Pages")).ToList())
+            {
+                _cache.Remove(key);
+            }
         }
         public async Task SetStatusAsync(int id, ContentStatus status)
         {

--- a/projects/Hood.Core/Services/MediaManager/IMediaManager.cs
+++ b/projects/Hood.Core/Services/MediaManager/IMediaManager.cs
@@ -10,6 +10,13 @@ namespace Hood.Services
 {
     public interface IMediaManager
     {
+        /// <summary>
+        /// True when media storage is configured (a storage connection string has been set in
+        /// Settings &gt; Media Settings). When false, uploads cannot proceed and callers should
+        /// surface a setup prompt rather than attempting storage operations.
+        /// </summary>
+        bool IsConfigured { get; }
+
         string GetBlobReference(string directory, string filename);
         /// <summary>
         /// Gets a safe filename for use with Azure storage. Unsafe characters will be removed.

--- a/projects/Hood.Core/Services/MediaManager/MediaManager.cs
+++ b/projects/Hood.Core/Services/MediaManager/MediaManager.cs
@@ -1,5 +1,6 @@
 ﻿using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Specialized;
+using Hood.Core;
 using Hood.Enums;
 using Hood.Extensions;
 using Hood.Interfaces;
@@ -34,6 +35,11 @@ namespace Hood.Services
             _env = env;
             _config = config;
         }
+
+        // Media storage is "configured" once a storage connection string (AzureKey) is set — ContainerName
+        // defaults to a generated value so it is never the deciding factor. Used to short-circuit uploads
+        // with a setup prompt instead of throwing when storage hasn't been wired up yet.
+        public bool IsConfigured => Engine.Settings?.Media?.AzureKey.IsSet() == true;
 
         private async Task<BlobContainerClient> GetClientAsync()
         {

--- a/projects/Hood.Core/Startup/IServiceCollectionExtensions.cs
+++ b/projects/Hood.Core/Startup/IServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Hood.Filters;
 using Hood.Models;
 using Hood.Services;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -17,6 +18,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Newtonsoft.Json.Serialization;
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Auth0.AspNetCore.Authentication;
@@ -136,6 +138,27 @@ namespace Hood.Startup
 
             services.ConfigureCache(config);
             services.ConfigureCacheProfiles();
+
+            services.ConfigureDataProtection(config);
+
+            return services;
+        }
+
+        // Persist the Data Protection key ring to a stable location when Hood:DataProtectionKeyPath is set,
+        // so antiforgery tokens / auth cookies survive app restarts, container rebuilds and multi-instance
+        // hosting. Without it the keys default to an ephemeral per-process/container location and reset on
+        // every rebuild (causing "The antiforgery token could not be decrypted"). The path is left unset by
+        // default — single-host installs work fine on the default key ring; containers/farms set the path.
+        private static IServiceCollection ConfigureDataProtection(this IServiceCollection services, IConfiguration config)
+        {
+            IDataProtectionBuilder dataProtection = services.AddDataProtection().SetApplicationName("Hood");
+
+            string keyPath = config["Hood:DataProtectionKeyPath"];
+            if (keyPath.IsSet())
+            {
+                Directory.CreateDirectory(keyPath);
+                dataProtection.PersistKeysToFileSystem(new DirectoryInfo(keyPath));
+            }
 
             return services;
         }
@@ -307,7 +330,11 @@ namespace Hood.Startup
         }
         public static IServiceCollection ConfigureProperty(this IServiceCollection services, IConfiguration config)
         {
-            services.AddDbContext<PropertyContext>(options => options.UseSqlServer(config["ConnectionStrings:DefaultConnection"]));
+            // PropertyListingView reads Include several collections (Media/FloorPlans/Metadata); split
+            // those into separate queries to avoid the cartesian-explosion single-query (EF Query[20504]).
+            services.AddDbContext<PropertyContext>(options => options.UseSqlServer(
+                config["ConnectionStrings:DefaultConnection"],
+                sql => sql.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery)));
             services.AddSingleton<IFTPService, FTPService>();
             services.AddSingleton<IPropertyImporter, BlmFileImporter>();
             services.AddScoped<IPropertyRepository, PropertyRepository>();
@@ -315,7 +342,11 @@ namespace Hood.Startup
         }
         public static IServiceCollection ConfigureContent(this IServiceCollection services, IConfiguration config)
         {
-            services.AddDbContext<ContentContext>(options => options.UseSqlServer(config["ConnectionStrings:DefaultConnection"]));
+            // ContentView reads Include several collections (Media/Metadata/Categories); split those into
+            // separate queries to avoid the cartesian-explosion single-query (EF Query[20504]).
+            services.AddDbContext<ContentContext>(options => options.UseSqlServer(
+                config["ConnectionStrings:DefaultConnection"],
+                sql => sql.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery)));
             services.AddSingleton<ContentCategoryCache>();
             services.AddSingleton<ContentByTypeCache>();
             services.AddScoped<IContentRepository, ContentRepository>();


### PR DESCRIPTION
## Overview

Batch of four independent v7 bugs surfaced during manual testing of the net10 rig. Each is a small, self-contained fix; commits are split per ticket (HOOD-68/69 share the startup file so they land together).

Closes HOOD-67
Closes HOOD-68
Closes HOOD-69
Closes HOOD-70

---

## What Changed and Why

**HOOD-70 — new page 404s on immediate preview**
`GetPages()` (which backs `PagesRouteConstraint`) caches the page list for 60 minutes, and nothing invalidated it on content change — so a freshly created page wasn't routable until the cache expired (404 on preview). `GetPages` applies no status filter, so a new *draft* page does resolve once the cache is cleared. Added `ClearPageCaches()` (clears every `.Pages` variant via the exposed cache keys) and call it on content add/update/delete; also wired the missing cache-clear + `ContentChanged` event into `DeleteAsync`.

**HOOD-67 — media upload error when storage isn't configured**
On a fresh install the upload threw a raw exception (logged as an error) because no storage connection string is set. Added `IMediaManager.IsConfigured` (keyed on the storage connection — `ContainerName` defaults to a generated value so it never decides) and guarded the upload action to return a clean *"configure storage in Settings > Media Settings"* message instead.

**HOOD-68 — Data Protection keys not persisted**
Keys lived in the container filesystem and reset on every rebuild → *"The antiforgery token could not be decrypted"*. Added `ConfigureDataProtection`: when `Hood:DataProtectionKeyPath` is set, persist the key ring there (`SetApplicationName("Hood")`). Compose now mounts a `hood-keys` volume at `/keys` and points the app at it. Single-host installs without the path keep working on the default key ring.

**HOOD-69 — EF multiple-collection-include warning**
`ContentView`/`PropertyListingView` reads `Include` several collections → one cartesian-explosion query + `Query[20504]`. Set `QuerySplittingBehavior.SplitQuery` on the Content and Property context registrations.

---

## Tests

- Full solution build clean on net10 (0 errors); `dotnet test`: **12 passed**.
- On the net10 Docker rig: app boots, `/` + `/account/login` = 200.
- **HOOD-68 verified**: the DP key is written to the `/keys` volume and the **same key survives a container rebuild** (no crypto/antiforgery errors).
- **HOOD-69 verified**: **0** `Query[20504]` warnings after the change.
- HOOD-67 / HOOD-70 are build-green and logic-verified; final confirmation is in-browser (authenticated upload / create-page-then-preview).

---

## Breaking Changes

- None. The DP key path is opt-in via config; the rig sets it.

---

**Docs updated:** yes — `DOCKER.md` documents the `hood-keys` volume.