### PR TITLE
HOOD-74 + HOOD-73 - Release readiness (warnings + readmes) + TinyMCE→HugeRTE migration

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,21 @@
     <PackageProjectUrl>https://github.com/HoodDigital/Hood</PackageProjectUrl>
     <RepositoryUrl>https://github.com/HoodDigital/Hood</RepositoryUrl>
     <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
+    <!-- Embed the repo readme in every package so it renders on the nuget.org listing. -->
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)readme.md" Pack="true" PackagePath="\" Visible="false" />
+  </ItemGroup>
+
+  <!--
+    Hood's theming / view-override model relies on Razor runtime compilation, which net10 deprecates
+    (ASPDEPR003). The dependency is intentional and load-bearing; a migration off runtime compilation
+    is tracked separately (HOOD-54). Suppress the obsolete-API warning rather than churn the architecture.
+  -->
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);ASPDEPR003</NoWarn>
   </PropertyGroup>
 
   <!-- MinVer: version from git tags, default pre-release phase `rc` -->

--- a/projects/Hood.Core/Exceptions/StartupException.cs
+++ b/projects/Hood.Core/Exceptions/StartupException.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Runtime.Serialization;
 using Hood.Enums;
 
 namespace Hood.Core
 {
-    [Serializable]
     public class StartupException : Exception
     {
         public StartupError Error { get; set; }
@@ -15,11 +13,6 @@ namespace Hood.Core
         }
 
         public StartupException(string message, Exception innerException, StartupError error) : base(message, innerException)
-        {
-            ProcessError(error);
-        }
-
-        protected StartupException(SerializationInfo info, StreamingContext context, StartupError error) : base(info, context)
         {
             ProcessError(error);
         }

--- a/projects/Hood.Core/ServiceProvider/HoodServiceProvider.cs
+++ b/projects/Hood.Core/ServiceProvider/HoodServiceProvider.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 
 namespace Hood.Core
 {
@@ -80,8 +79,8 @@ namespace Hood.Core
 
         public void Initialize(IServiceCollection services)
         {
-            //most of API providers require TLS 1.2 nowadays
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+            // (TLS 1.2+ is the runtime/OS default on net10 and ServicePointManager no longer
+            // affects HttpClient, so the old ServicePointManager.SecurityProtocol set is removed.)
 
             //set base application path
             var provider = services.BuildServiceProvider();

--- a/projects/Hood.Development/Areas/Admin/UI/Shared/_Scripts.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Shared/_Scripts.cshtml
@@ -5,7 +5,7 @@
 }
 <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
-<script src="https://cdn.tiny.cloud/1/@Engine.Configuration.Integrations.TinyMCE/tinymce/5/tinymce.min.js" referrerpolicy="origin"></script>
+<script src="https://cdn.jsdelivr.net/npm/hugerte@1/hugerte.min.js" referrerpolicy="origin"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.7.2/min/dropzone.min.js" integrity="sha512-9WciDs0XP20sojTJ9E7mChDXy6pcO0qHpwbEJID1YVavz2H6QBz5eLoDD8lseZOb2yGT8xDNIV7HIe1ZbuiDWg==" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@10.13.0/dist/sweetalert2.all.min.js" integrity="sha256-J9avsZWTdcAPp1YASuhlEH42nySYLmm0Jw1txwkuqQw=" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.js" integrity="sha512-d9xgZrVZpmmQlfonhQUvTR7lMPtO7NkZMkA0ABN3PHCbKA5nqylQ/yWlFAyY6hYgdF1Qh6nYiuADWwKB4C2WSw==" crossorigin="anonymous"></script>

--- a/projects/Hood.Development/package.json
+++ b/projects/Hood.Development/package.json
@@ -58,12 +58,12 @@
     "bootstrap": "^5.1.3",
     "chart.js": "^3.7.1",
     "dropzone": "^5.9.3",
+    "hugerte": "^1.0.10",
     "jquery": "^3.6.0",
     "jquery-slimscroll": "^1.3.8",
     "jquery-toast-plugin": "^1.3.2",
     "jquery-validation": "^1.19.4",
-    "sweetalert2": "^11.4.16",
-    "tinymce": "^5.10.3"
+    "sweetalert2": "^11.4.16"
   },
   "devDependencies": {
     "@lopatnov/rollup-plugin-uglify": "^2.1.2",

--- a/projects/Hood.Development/rollup.config.js
+++ b/projects/Hood.Development/rollup.config.js
@@ -34,7 +34,7 @@ const external = [
     'sweetalert2',
     'dropzone',
     '@simonwep/pickr',
-    'tinymce/tinymce',
+    'hugerte/hugerte',
     'chart.js'
 ];
 
@@ -135,7 +135,7 @@ export default commandLineArgs => {
                 sweetalert2: 'Swal',
                 dropzone: 'Dropzone',
                 '@simonwep/pickr': 'Pickr',
-                'tinymce/tinymce': 'tinymce',
+                'hugerte/hugerte': 'hugerte',
                 'chart.js': 'Chart'
             },
             sourcemap: sourcemaps,

--- a/projects/Hood.Development/src/ts/core/Editors.ts
+++ b/projects/Hood.Development/src/ts/core/Editors.ts
@@ -1,4 +1,4 @@
-import tinymce from 'tinymce/tinymce';
+import hugerte from 'hugerte/hugerte';
 
 import { MediaObject, MediaService } from './Media';
 import { ModalController } from './Modal';
@@ -44,17 +44,20 @@ export class Editors {
 
     richTextEditors() {
 
+        // HugeRTE (MIT fork of TinyMCE) — plugin/toolbar names updated for the v7-era API:
+        // dropped the v4-era 'print'/'contextmenu'/'paste'/'textcolor' (now built-in or removed),
+        // renamed 'styleselect' -> 'styles', and added the 'table' plugin the toolbar references.
+        const fullPlugins = 'advlist autolink lists link image charmap preview anchor media searchreplace visualblocks code fullscreen insertdatetime table';
+        const simplePlugins = 'advlist autolink lists link image charmap preview anchor media searchreplace visualblocks code fullscreen insertdatetime';
+        const fullToolbar = 'fullscreen code | styles forecolor backcolor | hoodimage link media image | bold italic | alignleft aligncenter alignright | bullist numlist | table | undo redo';
+        const simpleToolbar = 'fullscreen | bold italic | bullist numlist | undo redo | link';
 
-        tinymce.init({
+        hugerte.init({
             selector: '.tinymce-full',
             height: 150,
             menubar: false,
-            plugins: [
-                'advlist autolink lists link image charmap print preview anchor media',
-                'searchreplace visualblocks code fullscreen',
-                'insertdatetime media contextmenu paste textcolor'
-            ],
-            toolbar: "fullscreen code | styleselect forecolor backcolor | hoodimage link media image | bold italic | alignleft aligncenter alignright | bullist numlist | table | undo redo",
+            plugins: fullPlugins,
+            toolbar: fullToolbar,
             link_class_list: this.options.linkClasses,
             image_class_list: this.options.imageClasses,
             setup: this.setupCommands.bind(this),
@@ -62,51 +65,38 @@ export class Editors {
             content_css: [
                 '/dist/css/editor.css'
             ],
-
         });
 
-        tinymce.init({
+        hugerte.init({
             selector: '.tinymce-simple',
             height: 150,
-            plugins: [
-                'advlist autolink lists link image charmap print preview anchor media',
-                'searchreplace visualblocks code fullscreen',
-                'insertdatetime media contextmenu paste code'
-            ],
             menubar: false,
-            toolbar: 'fullscreen | bold italic | bullist numlist | undo redo | link',
+            plugins: simplePlugins,
+            toolbar: simpleToolbar,
             link_class_list: this.options.linkClasses,
             image_class_list: this.options.imageClasses,
             setup: this.setupCommands.bind(this),
             image_dimensions: false
         });
 
-        tinymce.init({
+        hugerte.init({
             selector: '.tinymce-full-content',
             height: 500,
             menubar: false,
-            plugins: [
-                'advlist autolink lists link image charmap print preview anchor media',
-                'searchreplace visualblocks code fullscreen',
-                'insertdatetime media contextmenu paste textcolor'
-            ],
-            toolbar: "fullscreen code | styleselect forecolor backcolor | hoodimage link media image | bold italic | alignleft aligncenter alignright | bullist numlist | table | undo redo",
+            plugins: fullPlugins,
+            toolbar: fullToolbar,
             link_class_list: this.options.linkClasses,
             image_class_list: this.options.imageClasses,
             setup: this.setupCommands.bind(this),
             image_dimensions: false
         });
 
-        tinymce.init({
+        hugerte.init({
             selector: '.tinymce-simple-content',
             height: 500,
-            plugins: [
-                'advlist autolink lists link image charmap print preview anchor media',
-                'searchreplace visualblocks code fullscreen',
-                'insertdatetime media contextmenu paste'
-            ],
             menubar: false,
-            toolbar: 'fullscreen | bold italic | bullist numlist | undo redo | link',
+            plugins: simplePlugins,
+            toolbar: simpleToolbar,
             link_class_list: this.options.linkClasses,
             image_class_list: this.options.imageClasses,
             image_dimensions: false

--- a/projects/Hood.Development/src/ts/core/Media.ts
+++ b/projects/Hood.Development/src/ts/core/Media.ts
@@ -6,7 +6,7 @@ import { DataList } from "./DataList";
 import { ModalController } from "./Modal";
 import { Validator } from "./Validator";
 import { Inline } from "./Inline";
-import { Editor } from "tinymce";
+import { Editor } from "hugerte";
 
 export declare interface MediaObject {
 

--- a/projects/Hood.Development/yarn.lock
+++ b/projects/Hood.Development/yarn.lock
@@ -3566,6 +3566,11 @@ http-cache-semantics@^4.0.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
+hugerte@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/hugerte/-/hugerte-1.0.10.tgz#e78e4e78b7a409be59234f35405a79a1f022c891"
+  integrity sha512-Uk7drnB4mqJUuXCtgDLDmBNSHNp7CH5juM3MGXE8HVJZwySW77xcdRaPss23vzneXY+dDoRABQcuFsBoa6s4CQ==
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
@@ -7398,11 +7403,6 @@ timers-ext@^0.1.7:
   dependencies:
     es5-ext "~0.10.46"
     next-tick "1"
-
-tinymce@^5.10.3:
-  version "5.10.3"
-  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-5.10.3.tgz#9485cf00159fd70c4948cb5e9dd49bce2a775899"
-  integrity sha512-O59ssHNnujWvSk5Gt8hIGrdNCMKVWVQv9F8siAgLTRgTh0t3NDHrP1UlLtCxArUi9DPWZvlBeUz8D5fJTu7vnA==
 
 to-absolute-glob@^2.0.0:
   version "2.0.2"

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Shared/_Scripts.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Shared/_Scripts.cshtml
@@ -5,7 +5,7 @@
 }
 <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
-<script src="https://cdn.tiny.cloud/1/@Engine.Configuration.Integrations.TinyMCE/tinymce/5/tinymce.min.js" referrerpolicy="origin"></script>
+<script src="https://cdn.jsdelivr.net/npm/hugerte@1/hugerte.min.js" referrerpolicy="origin"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.7.2/min/dropzone.min.js" integrity="sha512-9WciDs0XP20sojTJ9E7mChDXy6pcO0qHpwbEJID1YVavz2H6QBz5eLoDD8lseZOb2yGT8xDNIV7HIe1ZbuiDWg==" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@10.13.0/dist/sweetalert2.all.min.js" integrity="sha256-J9avsZWTdcAPp1YASuhlEH42nySYLmm0Jw1txwkuqQw=" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.js" integrity="sha512-d9xgZrVZpmmQlfonhQUvTR7lMPtO7NkZMkA0ABN3PHCbKA5nqylQ/yWlFAyY6hYgdF1Qh6nYiuADWwKB4C2WSw==" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Overview

Pre-release cleanup so the first v7 packages publish clean, plus the editor migration that removes the last runtime vulnerability.

Closes HOOD-74
Closes HOOD-73

(Also clears **HOOD-50** — with TinyMCE gone the npm runtime tree is 0-vuln; .NET was already 0; the dev-toolchain findings are deferred to HOOD-75.)

---

## HOOD-74 — clear build warnings + NuGet readmes

- **SYSLIB0014** — removed the obsolete `ServicePointManager.SecurityProtocol` set (no-op on net10: TLS 1.2+ is the default and it no longer affects `HttpClient`).
- **SYSLIB0051** — removed `StartupException`'s dead serialization ctor (it had a third param, so it was never a valid serialization ctor) + dropped `[Serializable]`.
- **ASPDEPR003** ×12 (Razor runtime compilation) — suppressed via `NoWarn` in `Directory.Build.props` **with a justification**: Hood's theming / view-override model relies on runtime compilation; migrating off it is HOOD-54.
- **NuGet readmes** — `PackageReadmeFile` embeds the repo readme in all 7 packages so they render on nuget.org (and the "missing a readme" warning is gone).

**Result:** `dotnet build` is **0 warnings / 0 errors**.

---

## HOOD-73 — TinyMCE → HugeRTE

TinyMCE moved its maintained editor behind a paid licence/cloud model, and the v5 line carries the **only runtime XSS CVEs** in the npm tree. Migrated to **HugeRTE** — the MIT fork of TinyMCE's last MIT commit, API-compatible, self-hosted, no API key. Templated off the CME Legacy retirement (CMEL-1/9/11/12), which shares Hood's editor integration.

- `package.json` / `yarn.lock`: `tinymce` → `hugerte` (1.0.10).
- `_Scripts.cshtml` (dev host + `Hood.UI.Admin`): Tiny Cloud CDN (API-key) → HugeRTE jsDelivr CDN (no key).
- `Editors.ts`: `tinymce.init` → `hugerte.init`; plugin/toolbar config updated for the v7-era API — dropped the v4-era `print`/`contextmenu`/`paste`/`textcolor`, renamed `styleselect` → `styles`, and added the `table` plugin the toolbar already referenced. The `hoodimage` custom button is unchanged (already on the v6+ registry API).
- `Media.ts`: `Editor` type from `hugerte`; rollup `external` + `globals` updated.

**Result:** **npm runtime audit = 0 vulnerabilities** (was 8, all TinyMCE).

---

## Tests

- `dotnet build` clean (0 warnings); `dotnet test`: **12 passed**.
- `yarn run package` builds clean; compiled admin JS uses `hugerte.init`; the HugeRTE CDN serves with no API key.
- Pack confirms the readme embeds in the packages.

> **Reviewer QA (can't be verified headlessly):** load the admin content editor and confirm HugeRTE renders — formatting, the **Insert image** (`hoodimage`) button → media modal, tables, and content save/load round-trip. The Docker rig has been rebuilt for this.

---

## Breaking Changes

- None for the editor (HugeRTE is API-compatible). The `Identity:Integrations:TinyMCE` appsettings key (the old Tiny Cloud API key) is now unused — harmless; a tidy-up of that settings property can ride a later cleanup.

**Docs updated:** not applicable.