### PR TITLE
HOOD-52: Fix hoodcms repository URL for npm provenance (first-release hotfix)

### DIFF
--- a/projects/Hood.Development/package.json
+++ b/projects/Hood.Development/package.json
@@ -21,7 +21,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/HoodDigital/hoodcms.git"
+    "url": "git+https://github.com/HoodDigital/Hood.git",
+    "directory": "projects/Hood.Development"
   },
   "license": "GPL-3.0",
   "author": "George Whysall",


### PR DESCRIPTION
## Overview

The first npm publish (PR #65's release) failed:

```
npm error 422 - Error verifying sigstore provenance bundle: Failed to validate repository
information: package.json: "repository.url" is "git+https://github.com/HoodDigital/hoodcms.git",
expected to match "https://github.com/HoodDigital/Hood" from provenance
```

npm trusted publishing attaches **sigstore provenance**, which checks that `package.json`'s `repository.url` matches the repo the workflow actually publishes from. It pointed at `HoodDigital/hoodcms` (the package name, not a real repo) while `hoodcms` is built and published from `HoodDigital/Hood`.

**NuGet published fine** — this only affected the provenance-checked npm side.

## Fix

`projects/Hood.Development/package.json`:
- `repository.url` → `git+https://github.com/HoodDigital/Hood.git`
- add `"directory": "projects/Hood.Development"` (the package lives in a subfolder)

Merging re-runs the frontend workflow; npm provenance will now validate and `hoodcms@7.0.0-rc.N` publishes to `next`.