### PR TITLE
HOOD-76: Remove internal pipeline info + client references from public repo

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -18,7 +18,7 @@ This file covers **local dev only**. For repo basics see [readme.md](readme.md).
 | `sqlserver` | `hood-sqlserver` | `14331` → 1433 | SQL Server 2022 Express. Data persists in the `sqlserver-data` named volume. |
 | `app` | `hood-app` | `5070` → 8080 | The `Hood.Development` ASP.NET Core host, built from [`Dockerfile`](Dockerfile). |
 
-Host port `14331` avoids clashes with a native SQL Server (`1433`) or other local dev stacks (bma-live uses `14330`). The SA password defaults to `Hood_Dev_Passw0rd!` — fine for throwaway local use; change it for anything exposed.
+Host port `14331` avoids clashes with a native SQL Server (`1433`) or other local dev stacks. The SA password defaults to `Hood_Dev_Passw0rd!` — fine for throwaway local use; change it for anything exposed.
 
 The app's **Data Protection keys** persist in the `hood-keys` named volume (mounted at `/keys`, set via `Hood__DataProtectionKeyPath`). This keeps antiforgery tokens and auth cookies valid across container rebuilds — without it the key ring resets on every rebuild and you'd hit *"The antiforgery token could not be decrypted"* until you cleared cookies.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - MSSQL_PID=Express
     ports:
       # Host 14331 → container 1433, avoiding clashes with a native SQL Server
-      # (1433) or other dev stacks (bma-live uses 14330).
+      # (1433) or other dev stacks.
       - "14331:1433"
     volumes:
       - sqlserver-data:/var/opt/mssql
@@ -52,7 +52,7 @@ services:
       # Persist the Data Protection key ring so antiforgery tokens / auth cookies survive rebuilds.
       - Hood__DataProtectionKeyPath=/keys
     ports:
-      # Host 5070 → container 8080 (bma-live uses 5050; keep Hood distinct).
+      # Host 5070 → container 8080 (avoids clashing with other local dev stacks).
       - "5070:8080"
     volumes:
       - hood-keys:/keys

--- a/readme.md
+++ b/readme.md
@@ -82,29 +82,6 @@ The deltas are small and drop no data-bearing columns — see [`sql/README.md`](
 exactly what each tier changes.
 
 
-## Releases & branching
-
-Hood uses a trunk-based flow with automatic, git-derived versioning (MinVer) and GitHub Actions.
-
-**Branching.** Work happens on feature branches → PR → squash-merge to `master`. PRs run build + `dotnet test` and `npm run package` as gates; nothing merges red.
-
-**Versioning is automatic — never set a version by hand.** [MinVer](https://github.com/adamralph/minver) derives it from git:
-
-| Git state | Version | Published |
-|---|---|---|
-| A merge to `master` | `7.0.0-rc.N` (`N` = merges since the last tag) | NuGet.org **prerelease** + npm dist-tag **`next`** |
-| A GitHub Release tag `v7.0.0` | `7.0.0` (clean) | NuGet.org **stable** + npm dist-tag **`latest`** |
-
-So **every merge ships a prerelease automatically**, and **cutting a `v7.0.0` GitHub Release ships the stable**. To release a stable, draft a GitHub Release with the tag `v7.0.0` (matching the `MinVerMinimumMajorMinor` in [`Directory.Build.props`](Directory.Build.props)).
-
-**Pipelines** ([`.github/workflows`](.github/workflows)): `backend.yml` packs the 8 NuGet packages (the seven libraries plus the `hood-schema` CLI tool); `frontend.yml` builds + publishes the `hoodcms` npm package (its version is derived from the same MinVer value, so npm and NuGet stay in lockstep). They're path-filtered, so a backend-only change doesn't rebuild the frontend and vice versa.
-
-**Publishing — no tokens.** Both registries use OIDC **trusted publishing**: GitHub mints a short-lived identity token (`id-token: write`) that the registry exchanges for a temporary credential at publish time. Nothing long-lived is stored in GitHub. Both publish jobs run in the **`release`** GitHub environment (the trusted-publisher configs require it), and provenance is attached automatically.
-
-- **npm** — [trusted publisher](https://docs.npmjs.com/trusted-publishers) on the `hoodcms` package pointing at `frontend.yml` + environment `release`. `npm publish` (npm ≥ 11.5.1) does the exchange.
-- **NuGet** — [trusted publisher](https://learn.microsoft.com/nuget/nuget-org/trusted-publishing) on the packages pointing at `backend.yml` + environment `release`. The `NuGet/login` action exchanges the OIDC token for a temporary key; it reads your nuget.org username from the `NUGET_USER` repo variable. (`NuGet/login` isn't a GitHub-authored action, so it must be added to the repo's allowed-actions list.)
-
-
 ## Full documentation
 
 Documentation is a work in progress. The most useful references today:

--- a/sql/README.md
+++ b/sql/README.md
@@ -65,7 +65,7 @@ The v7 delta is small and **drops no data-bearing base-table columns**:
 
 (The reporting views are applied separately — the `sql/7.0/views/*` scripts, idempotent DROP/CREATE — so they're shared by fresh installs, upgrades and the runner.)
 
-Consumers on the 6.1.x golden-DB baseline (e.g. bma-live) take a **clean, zero-data-loss** upgrade — verified that nothing reads any removed field.
+Consumers on the 6.1.x baseline take a **clean, zero-data-loss** upgrade — verified that nothing reads any removed field.
 
 ## Regenerating the SQL after a model change
 


### PR DESCRIPTION
Follow-up to #67: the repo is public — internal operational detail doesn't belong in tracked files.

- Readme's **Releases & branching** section removed (MinVer flow, pipelines, OIDC trusted-publishing setup). Parked in an internal Linear document for maintainers.
- Client project references (**bma-live**, introduced in #54/#56 comments and sql/README) scrubbed from DOCKER.md, docker-compose.yml and sql/README.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
