### PR TITLE
HOOD-78: Remaining InspectCode categories — suppression block emptied, 438 findings fixed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -147,7 +147,6 @@ resharper_unused_member_local_highlighting = none
 resharper_not_accessed_field_local_highlighting = none
 resharper_unused_parameter_local_highlighting = none
 resharper_unused_parameter_global_highlighting = none
-resharper_invalid_xml_doc_comment_highlighting = none
 
 # --- Markup / web noise ------------------------------------------------------------
 # Legacy theme markup renders fine; paths are theme-relative; ids resolve at

--- a/.editorconfig
+++ b/.editorconfig
@@ -138,9 +138,6 @@ resharper_markup_text_typo_highlighting = none
 # catches, modified-closure captures, virtual calls in ctors). Fixing them is
 # behavioural-risk work the HOOD-62 mechanical sweep must not do. Tracked to
 # re-enable + fix category-by-category in HOOD-78.
-resharper_unused_member_local_highlighting = none
-resharper_not_accessed_field_local_highlighting = none
-resharper_unused_parameter_local_highlighting = none
 resharper_unused_parameter_global_highlighting = none
 
 # --- Markup / web noise ------------------------------------------------------------

--- a/.editorconfig
+++ b/.editorconfig
@@ -138,9 +138,6 @@ resharper_markup_text_typo_highlighting = none
 # catches, modified-closure captures, virtual calls in ctors). Fixing them is
 # behavioural-risk work the HOOD-62 mechanical sweep must not do. Tracked to
 # re-enable + fix category-by-category in HOOD-78.
-resharper_unused_variable_highlighting = none
-resharper_unused_local_variable_highlighting = none
-resharper_not_accessed_variable_highlighting = none
 resharper_redundant_assignment_highlighting = none
 resharper_empty_constructor_highlighting = none
 resharper_unused_member_local_highlighting = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -138,7 +138,6 @@ resharper_markup_text_typo_highlighting = none
 # catches, modified-closure captures, virtual calls in ctors). Fixing them is
 # behavioural-risk work the HOOD-62 mechanical sweep must not do. Tracked to
 # re-enable + fix category-by-category in HOOD-78.
-resharper_redundant_assignment_highlighting = none
 resharper_empty_constructor_highlighting = none
 resharper_unused_member_local_highlighting = none
 resharper_not_accessed_field_local_highlighting = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -133,13 +133,6 @@ resharper_identifier_typo_highlighting = none
 resharper_markup_attribute_typo_highlighting = none
 resharper_markup_text_typo_highlighting = none
 
-# --- Known code smells — ticketed, not hidden silently --------------------------
-# Real findings (unused locals, multiple enumeration, dead assignments, empty
-# catches, modified-closure captures, virtual calls in ctors). Fixing them is
-# behavioural-risk work the HOOD-62 mechanical sweep must not do. Tracked to
-# re-enable + fix category-by-category in HOOD-78.
-resharper_unused_parameter_global_highlighting = none
-
 # --- Markup / web noise ------------------------------------------------------------
 # Legacy theme markup renders fine; paths are theme-relative; ids resolve at
 # runtime through Hood's composition.

--- a/.editorconfig
+++ b/.editorconfig
@@ -138,7 +138,6 @@ resharper_markup_text_typo_highlighting = none
 # catches, modified-closure captures, virtual calls in ctors). Fixing them is
 # behavioural-risk work the HOOD-62 mechanical sweep must not do. Tracked to
 # re-enable + fix category-by-category in HOOD-78.
-resharper_empty_constructor_highlighting = none
 resharper_unused_member_local_highlighting = none
 resharper_not_accessed_field_local_highlighting = none
 resharper_unused_parameter_local_highlighting = none

--- a/projects/Hood.Admin/Controllers/ContentController.cs
+++ b/projects/Hood.Admin/Controllers/ContentController.cs
@@ -6,8 +6,5 @@ namespace Hood.Areas.Admin.Controllers
 {
     [Area("Admin")]
     [Authorize(Roles = "SuperUser,Admin,Editor")]
-    public class ContentController : BaseContentController
-    {
-        public ContentController() { }
-    }
+    public class ContentController : BaseContentController { }
 }

--- a/projects/Hood.Admin/Controllers/ContentTypeController.cs
+++ b/projects/Hood.Admin/Controllers/ContentTypeController.cs
@@ -6,8 +6,5 @@ namespace Hood.Areas.Admin.Controllers
 {
     [Area("Admin")]
     [Authorize(Roles = "SuperUser,Admin,Editor")]
-    public class ContentTypeController : BaseContentTypeController
-    {
-        public ContentTypeController() { }
-    }
+    public class ContentTypeController : BaseContentTypeController { }
 }

--- a/projects/Hood.Admin/Controllers/HomeController.cs
+++ b/projects/Hood.Admin/Controllers/HomeController.cs
@@ -6,8 +6,5 @@ namespace Hood.Areas.Admin.Controllers
 {
     [Area("Admin")]
     [Authorize(Roles = "SuperUser,Admin,Editor")]
-    public class HomeController : BaseHomeController
-    {
-        public HomeController() { }
-    }
+    public class HomeController : BaseHomeController { }
 }

--- a/projects/Hood.Admin/Controllers/ImportController.cs
+++ b/projects/Hood.Admin/Controllers/ImportController.cs
@@ -6,8 +6,5 @@ namespace Hood.Areas.Admin.Controllers
 {
     [Area("Admin")]
     [Authorize(Roles = "SuperUser,Admin")]
-    public class ImportController : BaseImportController
-    {
-        public ImportController() { }
-    }
+    public class ImportController : BaseImportController { }
 }

--- a/projects/Hood.Admin/Controllers/MailController.cs
+++ b/projects/Hood.Admin/Controllers/MailController.cs
@@ -6,8 +6,5 @@ namespace Hood.Areas.Admin.Controllers
 {
     [Area("Admin")]
     [Authorize(Roles = "SuperUser,Admin")]
-    public class MailController : BaseMailController
-    {
-        public MailController() { }
-    }
+    public class MailController : BaseMailController { }
 }

--- a/projects/Hood.Admin/Controllers/MediaController.cs
+++ b/projects/Hood.Admin/Controllers/MediaController.cs
@@ -6,8 +6,5 @@ namespace Hood.Areas.Admin.Controllers
 {
     [Area("Admin")]
     [Authorize(Roles = "SuperUser,Admin,Editor")]
-    public class MediaController : BaseMediaController
-    {
-        public MediaController() { }
-    }
+    public class MediaController : BaseMediaController { }
 }

--- a/projects/Hood.Admin/Controllers/PropertyController.cs
+++ b/projects/Hood.Admin/Controllers/PropertyController.cs
@@ -6,8 +6,5 @@ namespace Hood.Areas.Admin.Controllers
 {
     [Area("Admin")]
     [Authorize(Roles = "SuperUser,Admin,Editor")]
-    public class PropertyController : BasePropertyController
-    {
-        public PropertyController() { }
-    }
+    public class PropertyController : BasePropertyController { }
 }

--- a/projects/Hood.Admin/Controllers/SettingsController.cs
+++ b/projects/Hood.Admin/Controllers/SettingsController.cs
@@ -6,8 +6,5 @@ namespace Hood.Areas.Admin.Controllers
 {
     [Area("Admin")]
     [Authorize(Roles = "SuperUser,Admin")]
-    public class SettingsController : BaseSettingsController
-    {
-        public SettingsController() { }
-    }
+    public class SettingsController : BaseSettingsController { }
 }

--- a/projects/Hood.Admin/Controllers/ThemesController.cs
+++ b/projects/Hood.Admin/Controllers/ThemesController.cs
@@ -6,8 +6,5 @@ namespace Hood.Areas.Admin.Controllers
 {
     [Area("Admin")]
     [Authorize(Roles = "SuperUser,Admin")]
-    public class ThemesController : BaseThemesController
-    {
-        public ThemesController() { }
-    }
+    public class ThemesController : BaseThemesController { }
 }

--- a/projects/Hood.Admin/Controllers/UsersController.cs
+++ b/projects/Hood.Admin/Controllers/UsersController.cs
@@ -7,8 +7,5 @@ namespace Hood.Areas.Admin.Controllers
     [Authorize(Roles = "SuperUser,Admin")]
     // Standard ASP.NET Identity is the default backend; this admin controller derives from the
     // standard base. Auth0 deployments substitute Hood.Admin.BaseControllers.Auth0UsersController.
-    public class UsersController : Hood.Admin.BaseControllers.UsersController
-    {
-        public UsersController() { }
-    }
+    public class UsersController : Hood.Admin.BaseControllers.UsersController { }
 }

--- a/projects/Hood.Core/Attributes/DisableForAuth0Attribute.cs
+++ b/projects/Hood.Core/Attributes/DisableForAuth0Attribute.cs
@@ -3,7 +3,6 @@ using Hood.Core;
 using Hood.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.Extensions.Configuration;
 
 namespace Hood.Attributes
 {

--- a/projects/Hood.Core/Attributes/DisableForAuth0Attribute.cs
+++ b/projects/Hood.Core/Attributes/DisableForAuth0Attribute.cs
@@ -12,13 +12,6 @@ namespace Hood.Attributes
     /// </summary>
     public class DisableForAuth0Attribute : ActionFilterAttribute
     {
-        private readonly IConfiguration _config;
-
-        public DisableForAuth0Attribute()
-        {
-            _config = Engine.Services.Resolve<IConfiguration>();
-        }
-
         public override void OnActionExecuting(ActionExecutingContext context)
         {
             if (Engine.Auth0Enabled)

--- a/projects/Hood.Core/Attributes/DisconnectedUsersOnlyAttribute.cs
+++ b/projects/Hood.Core/Attributes/DisconnectedUsersOnlyAttribute.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Hood.Core;
 using Hood.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.AspNetCore.Routing;
 
 namespace Hood.Attributes
 {

--- a/projects/Hood.Core/Attributes/DisconnectedUsersOnlyAttribute.cs
+++ b/projects/Hood.Core/Attributes/DisconnectedUsersOnlyAttribute.cs
@@ -21,7 +21,6 @@ namespace Hood.Attributes
     {
         public Task OnAuthorizationAsync(AuthorizationFilterContext context)
         {
-            var linkGenerator = Engine.Services.Resolve<LinkGenerator>();
             if (
                 !context.HttpContext.User.Identity.IsAuthenticated
                 || !context.HttpContext.User.RequiresConnection()

--- a/projects/Hood.Core/Attributes/FormUpdatableAttribute.cs
+++ b/projects/Hood.Core/Attributes/FormUpdatableAttribute.cs
@@ -1,8 +1,5 @@
 namespace Hood.Attributes
 {
     [System.AttributeUsage(System.AttributeTargets.Property)]
-    public class FormUpdatableAttribute : System.Attribute
-    {
-        public FormUpdatableAttribute() { }
-    }
+    public class FormUpdatableAttribute : System.Attribute { }
 }

--- a/projects/Hood.Core/Attributes/RouteIgnoreAttribute.cs
+++ b/projects/Hood.Core/Attributes/RouteIgnoreAttribute.cs
@@ -1,8 +1,5 @@
 namespace Hood.Attributes
 {
     [System.AttributeUsage(System.AttributeTargets.Property)]
-    public class RouteIgnoreAttribute : System.Attribute
-    {
-        public RouteIgnoreAttribute() { }
-    }
+    public class RouteIgnoreAttribute : System.Attribute { }
 }

--- a/projects/Hood.Core/BaseControllers/AccountController.cs
+++ b/projects/Hood.Core/BaseControllers/AccountController.cs
@@ -145,7 +145,6 @@ namespace Hood.BaseControllers
             string returnUrl = null
         )
         {
-            AccountSettings accountSettings = Engine.Settings.Account;
             ViewData["ReturnUrl"] = returnUrl;
 
             if (ModelState.IsValid)

--- a/projects/Hood.Core/BaseControllers/AccountController.cs
+++ b/projects/Hood.Core/BaseControllers/AccountController.cs
@@ -174,11 +174,7 @@ namespace Hood.BaseControllers
                     ApplicationUser user = await _userManager.FindByNameAsync(model.Username);
                     if (Engine.Settings.Account.RequireEmailConfirmation && !user.EmailConfirmed)
                     {
-                        await SendVerificationEmail(
-                            user,
-                            User.GetUserId(),
-                            Url.AbsoluteAction("Login", "Account")
-                        );
+                        await SendVerificationEmail(user, Url.AbsoluteAction("Login", "Account"));
                         return RedirectToAction(nameof(ConfirmRequired), new { user = user.Id });
                     }
 
@@ -303,11 +299,7 @@ namespace Hood.BaseControllers
 
                     if (Engine.Settings.Account.RequireEmailConfirmation)
                     {
-                        await SendVerificationEmail(
-                            user,
-                            User.GetUserId(),
-                            Url.AbsoluteAction("Login", "Account")
-                        );
+                        await SendVerificationEmail(user, Url.AbsoluteAction("Login", "Account"));
                         return RedirectToAction(
                             nameof(AccountController.ConfirmRequired),
                             "Account"
@@ -435,11 +427,7 @@ namespace Hood.BaseControllers
             try
             {
                 var user = await GetCurrentUserOrThrow();
-                await SendVerificationEmail(
-                    user,
-                    User.GetUserId(),
-                    Url.AbsoluteAction("Login", "Account")
-                );
+                await SendVerificationEmail(user, Url.AbsoluteAction("Login", "Account"));
                 SaveMessage = $"Email verification has been resent.";
                 MessageType = AlertType.Success;
             }
@@ -669,7 +657,6 @@ namespace Hood.BaseControllers
 
         protected virtual async Task SendVerificationEmail(
             ApplicationUser localUser,
-            string userId,
             string returnUrl
         )
         {

--- a/projects/Hood.Core/BaseControllers/Admin/Auth0UsersController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/Auth0UsersController.cs
@@ -685,9 +685,6 @@ namespace Hood.Admin.BaseControllers
                 UserManager<Auth0User> userManager = Engine.Services.Resolve<
                     UserManager<Auth0User>
                 >();
-                SignInManager<Auth0User> signInManager = Engine.Services.Resolve<
-                    SignInManager<Auth0User>
-                >();
                 Auth0User user = await userManager.FindByIdAsync(id);
                 string token = await userManager.GeneratePasswordResetTokenAsync(user);
                 IdentityResult result = await userManager.ResetPasswordAsync(user, token, password);

--- a/projects/Hood.Core/BaseControllers/Admin/ContentController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/ContentController.cs
@@ -51,7 +51,7 @@ namespace Hood.Admin.BaseControllers
         [Route("admin/content/{id}/edit/")]
         public virtual async Task<IActionResult> Edit(int id)
         {
-            var model = await _content.GetContentByIdAsync(id, true, false);
+            var model = await _content.GetContentByIdAsync(id, true);
             model = await GetEditorModel(model);
             if (model == null)
                 return NotFound();
@@ -65,7 +65,7 @@ namespace Hood.Admin.BaseControllers
         {
             try
             {
-                var modelToUpdate = await _content.GetContentByIdAsync(model.Id, true, false);
+                var modelToUpdate = await _content.GetContentByIdAsync(model.Id, true);
                 modelToUpdate = await GetEditorModel(modelToUpdate);
 
                 var updatedFields = Request.Form.Keys.ToHashSet();
@@ -288,7 +288,7 @@ namespace Hood.Admin.BaseControllers
         [Route("admin/content/categories/list-content/{id}/")]
         public virtual async Task<IActionResult> CategoriesContentAsync(int id)
         {
-            var model = await _content.GetContentByIdAsync(id, true, false);
+            var model = await _content.GetContentByIdAsync(id, true);
             return View("_List_Categories_Content", model);
         }
 

--- a/projects/Hood.Core/BaseControllers/Admin/ContentController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/ContentController.cs
@@ -314,7 +314,7 @@ namespace Hood.Admin.BaseControllers
                     throw new Exception("You need to enter a category!");
                 }
 
-                ContentCategory categoryResult = await _content.AddCategoryAsync(category);
+                await _content.AddCategoryAsync(category);
                 _contentCategoryCache.ResetCache();
 
                 return new Response(true, "Added the category.");
@@ -403,7 +403,6 @@ namespace Hood.Admin.BaseControllers
             try
             {
                 await _content.SetStatusAsync(id, status);
-                Content content = await _content.GetContentByIdAsync(id);
                 return new Response(true, "Content status has been updated successfully.");
             }
             catch (Exception ex)
@@ -561,7 +560,6 @@ namespace Hood.Admin.BaseControllers
                 Content content = await _contentDb
                     .Content.Where(p => p.Id == id)
                     .FirstOrDefaultAsync();
-                MediaObject media = _db.Media.SingleOrDefault(m => m.Id == model.MediaId);
                 string cacheKey = typeof(Content) + ".Single." + id;
 
                 switch (model.FieldName)
@@ -624,7 +622,7 @@ namespace Hood.Admin.BaseControllers
                         throw new Exception("There are no files selected!");
                     }
 
-                    var directory = await _content.GetDirectoryAsync();
+                    await _content.GetDirectoryAsync(); // throws if the site directory is missing
                     foreach (int mediaId in media)
                     {
                         // load the media object from db

--- a/projects/Hood.Core/BaseControllers/Admin/ContentTypeController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/ContentTypeController.cs
@@ -112,7 +112,7 @@ namespace Hood.Admin.BaseControllers
                 fields.Add(model);
                 contentType.CustomFields = fields;
 
-                ContentType modelToUpdate = SaveContentType(contentType, id);
+                SaveContentType(contentType, id);
 
                 return new Response(true, $"The field was added successfully.");
             }
@@ -137,7 +137,7 @@ namespace Hood.Admin.BaseControllers
                 fields.RemoveAll(f => f.Name == name);
                 contentType.CustomFields = fields;
 
-                ContentType modelToUpdate = SaveContentType(contentType, id);
+                SaveContentType(contentType, id);
 
                 return new Response(true, $"The field was removed successfully.");
             }

--- a/projects/Hood.Core/BaseControllers/Admin/ContentTypeController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/ContentTypeController.cs
@@ -258,7 +258,7 @@ namespace Hood.Admin.BaseControllers
                 var modelToUpdate = Engine.Settings.Content.GetContentType(id);
 
                 var updatedFields = Request.Form.Keys.ToHashSet();
-                modelToUpdate = modelToUpdate.UpdateFromFormModel(model, updatedFields);
+                modelToUpdate.UpdateFromFormModel(model, updatedFields);
 
                 modelToUpdate = SaveContentType(model, id);
                 if (model.Type != id)

--- a/projects/Hood.Core/BaseControllers/Admin/HomeController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/HomeController.cs
@@ -7,8 +7,6 @@ namespace Hood.Admin.BaseControllers
 {
     public abstract class BaseHomeController : BaseController
     {
-        public BaseHomeController() { }
-
         [Route("admin/")]
         public virtual IActionResult Index()
         {

--- a/projects/Hood.Core/BaseControllers/Admin/ImportController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/ImportController.cs
@@ -35,7 +35,7 @@ namespace Hood.Admin.BaseControllers
                 && !_blm.IsRunning()
             )
             {
-                await _blm.RunUpdate(HttpContext, "none", "none");
+                await _blm.RunUpdate("none", "none");
                 return StatusCode(200);
             }
 
@@ -71,7 +71,7 @@ namespace Hood.Admin.BaseControllers
         public virtual async Task<IActionResult> BlmImporterStart()
         {
             _blm.Kill();
-            await _blm.RunUpdate(HttpContext, "none", "none");
+            await _blm.RunUpdate("none", "none");
             return Json(new { success = true });
         }
 

--- a/projects/Hood.Core/BaseControllers/Admin/ImportController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/ImportController.cs
@@ -71,7 +71,6 @@ namespace Hood.Admin.BaseControllers
         public virtual async Task<IActionResult> BlmImporterStart()
         {
             _blm.Kill();
-            var user = Engine.Account.GetLocalUserId();
             await _blm.RunUpdate(HttpContext, "none", "none");
             return Json(new { success = true });
         }

--- a/projects/Hood.Core/BaseControllers/Admin/MailController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/MailController.cs
@@ -10,8 +10,6 @@ namespace Hood.Admin.BaseControllers
 {
     public abstract class BaseMailController : BaseController
     {
-        public BaseMailController() { }
-
         [Route("admin/mail/preview/plain/")]
         public virtual IActionResult Plain()
         {

--- a/projects/Hood.Core/BaseControllers/Admin/MediaController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/MediaController.cs
@@ -16,8 +16,6 @@ namespace Hood.Admin.BaseControllers
 {
     public abstract class BaseMediaController : BaseController
     {
-        public BaseMediaController() { }
-
         [Route("admin/media/list/")]
         public virtual async Task<IActionResult> List(
             MediaListModel model,

--- a/projects/Hood.Core/BaseControllers/Admin/PropertyController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/PropertyController.cs
@@ -56,7 +56,7 @@ namespace Hood.Admin.BaseControllers
         [Route("admin/property/{id}/edit/")]
         public virtual async Task<IActionResult> Edit(int id)
         {
-            PropertyListing model = await _property.GetPropertyByIdAsync(id, true);
+            PropertyListing model = await _property.GetPropertyByIdAsync(id);
             model = await LoadAgents(model);
             model.AutoGeocode = true;
             return View(model);
@@ -479,7 +479,7 @@ namespace Hood.Admin.BaseControllers
         [Route("admin/property/{id}/gallery/")]
         public virtual async Task<IActionResult> Gallery(int id)
         {
-            PropertyListing model = await _property.GetPropertyByIdAsync(id, true);
+            PropertyListing model = await _property.GetPropertyByIdAsync(id);
             return View("_List_PropertyMedia", model);
         }
 
@@ -562,7 +562,7 @@ namespace Hood.Admin.BaseControllers
         [Route("admin/property/{id}/floorplans/")]
         public virtual async Task<IActionResult> FloorPlans(int id)
         {
-            PropertyListing model = await _property.GetPropertyByIdAsync(id, true);
+            PropertyListing model = await _property.GetPropertyByIdAsync(id);
             return View("_List_PropertyFloorplans", model);
         }
 

--- a/projects/Hood.Core/BaseControllers/Admin/PropertyController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/PropertyController.cs
@@ -444,8 +444,6 @@ namespace Hood.Admin.BaseControllers
                     throw new Exception("Could not load property to remove media.");
                 }
 
-                MediaObject media = _db.Media.SingleOrDefault(m => m.Id == model.MediaId);
-
                 switch (model.FieldName)
                 {
                     case nameof(PropertyListing.FeaturedImage):
@@ -507,7 +505,7 @@ namespace Hood.Admin.BaseControllers
                         throw new Exception("There are no files selected!");
                     }
 
-                    var directory = await _property.GetDirectoryAsync();
+                    await _property.GetDirectoryAsync(); // throws if the site directory is missing
                     foreach (int mediaId in media)
                     {
                         // load the media object from db
@@ -589,7 +587,7 @@ namespace Hood.Admin.BaseControllers
                         throw new Exception("There are no files selected!");
                     }
 
-                    var directory = await _property.GetDirectoryAsync();
+                    await _property.GetDirectoryAsync(); // throws if the site directory is missing
                     foreach (int mediaId in media)
                     {
                         // load the media object from db

--- a/projects/Hood.Core/BaseControllers/Admin/PropertyController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/PropertyController.cs
@@ -83,7 +83,7 @@ namespace Hood.Admin.BaseControllers
 
                 if (model.AutoGeocode)
                 {
-                    var StatusMessage = "";
+                    string StatusMessage;
                     try
                     {
                         try
@@ -651,14 +651,6 @@ namespace Hood.Admin.BaseControllers
                 if (property == null)
                 {
                     throw new Exception("Property not found.");
-                }
-
-                int? count = await _propertyDb
-                    .PropertyMetadata.Where(m => m.Name.Contains($"{name}"))
-                    .CountAsync();
-                if (!count.HasValue)
-                {
-                    count = 0;
                 }
 
                 PropertyMeta meta = new PropertyMeta()

--- a/projects/Hood.Core/BaseControllers/Admin/SettingsController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/SettingsController.cs
@@ -12,8 +12,6 @@ namespace Hood.Admin.BaseControllers
 {
     public abstract class BaseSettingsController : BaseController
     {
-        public BaseSettingsController() { }
-
         [Route("admin/settings/basics/")]
         public virtual IActionResult Basics()
         {

--- a/projects/Hood.Core/BaseControllers/Admin/ThemesController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/ThemesController.cs
@@ -11,8 +11,6 @@ namespace Hood.Admin.BaseControllers
 {
     public abstract class BaseThemesController : BaseController
     {
-        public BaseThemesController() { }
-
         [Route("admin/theme/")]
         public virtual IActionResult Index(ThemeListView model) => List(model, "Index");
 

--- a/projects/Hood.Core/BaseControllers/Admin/UsersController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/UsersController.cs
@@ -621,9 +621,6 @@ namespace Hood.Admin.BaseControllers
                 UserManager<ApplicationUser> userManager = Engine.Services.Resolve<
                     UserManager<ApplicationUser>
                 >();
-                SignInManager<ApplicationUser> signInManager = Engine.Services.Resolve<
-                    SignInManager<ApplicationUser>
-                >();
                 ApplicationUser user = await userManager.FindByIdAsync(id);
                 string token = await userManager.GeneratePasswordResetTokenAsync(user);
                 IdentityResult result = await userManager.ResetPasswordAsync(user, token, password);

--- a/projects/Hood.Core/BaseControllers/Api/HomeController.cs
+++ b/projects/Hood.Core/BaseControllers/Api/HomeController.cs
@@ -7,8 +7,6 @@ namespace Hood.Api.BaseControllers
     [ApiController]
     public abstract class HomeController : ControllerBase
     {
-        public HomeController() { }
-
         private const string publicMessage =
             "The API doesn't require an access token to share this message.";
         private const string protectedMessage = "The API successfully validated your access token.";

--- a/projects/Hood.Core/BaseControllers/Auth0AccountController.cs
+++ b/projects/Hood.Core/BaseControllers/Auth0AccountController.cs
@@ -551,7 +551,7 @@ namespace Hood.BaseControllers
         [Route("account/auth/disconnected")]
         public virtual async Task<IActionResult> DisconnectAccountComplete()
         {
-            var user = await GetCurrentUserOrThrow();
+            await GetCurrentUserOrThrow();
             return View();
         }
 
@@ -671,7 +671,7 @@ namespace Hood.BaseControllers
             }
             if (remoteUser.Provider == Authentication.AuthProviderName)
             {
-                var ticket = await _auth0.CreatePasswordChangeTicket(remoteUser);
+                await _auth0.CreatePasswordChangeTicket(remoteUser);
             }
             else
             {

--- a/projects/Hood.Core/BaseControllers/ErrorController.cs
+++ b/projects/Hood.Core/BaseControllers/ErrorController.cs
@@ -9,8 +9,6 @@ namespace Hood.BaseControllers
     [Route("error")]
     public abstract class ErrorController : BaseController
     {
-        public ErrorController() { }
-
         [Route("500")]
         public virtual async System.Threading.Tasks.Task<IActionResult> AppError()
         {

--- a/projects/Hood.Core/BaseControllers/ErrorController.cs
+++ b/projects/Hood.Core/BaseControllers/ErrorController.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using Hood.Core;
 using Hood.Extensions;
 using Hood.Models;
 using Microsoft.AspNetCore.Diagnostics;

--- a/projects/Hood.Core/BaseControllers/ErrorController.cs
+++ b/projects/Hood.Core/BaseControllers/ErrorController.cs
@@ -34,8 +34,6 @@ namespace Hood.BaseControllers
         [Route("404")]
         public virtual async System.Threading.Tasks.Task<IActionResult> PageNotFound()
         {
-            BasicSettings basicSettings = Engine.Settings.Basic;
-
             ErrorModel model = new ErrorModel { OriginalUrl = "unknown", Code = 404 };
 
             model.OriginalUrl = HttpContext.GetSiteUrl().TrimEnd('/');

--- a/projects/Hood.Core/BaseControllers/HoodController.cs
+++ b/projects/Hood.Core/BaseControllers/HoodController.cs
@@ -12,8 +12,6 @@ namespace Hood.BaseControllers
 {
     public abstract class HoodController : BaseController
     {
-        public HoodController() { }
-
         [HttpPost]
         [Route("hood/contact/send/")]
         [Route("hood/process-contact-form/")]

--- a/projects/Hood.Core/BaseControllers/ImageController.cs
+++ b/projects/Hood.Core/BaseControllers/ImageController.cs
@@ -9,8 +9,6 @@ namespace Hood.BaseControllers
 {
     public class ImagesController : Controller
     {
-        public ImagesController() { }
-
         #region Login Page Backgrounds
 
         [HttpGet]

--- a/projects/Hood.Core/BaseControllers/InstallController.cs
+++ b/projects/Hood.Core/BaseControllers/InstallController.cs
@@ -8,7 +8,6 @@ using Hood.Services;
 using Hood.ViewModels;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 namespace Hood.BaseControllers

--- a/projects/Hood.Core/BaseControllers/InstallController.cs
+++ b/projects/Hood.Core/BaseControllers/InstallController.cs
@@ -25,7 +25,7 @@ namespace Hood.BaseControllers
         [Route("/install")]
         public IActionResult Install()
         {
-            if (Engine.Services.Installed)
+            if (Engine.Services.Installed && Engine.Services.Seeded)
             {
                 return RedirectToAction("Index", "Home");
             }
@@ -42,7 +42,7 @@ namespace Hood.BaseControllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Install(InstallModel model)
         {
-            if (Engine.Services.Installed)
+            if (Engine.Services.Installed && Engine.Services.Seeded)
             {
                 return RedirectToAction("Index", "Home");
             }

--- a/projects/Hood.Core/BaseControllers/InstallController.cs
+++ b/projects/Hood.Core/BaseControllers/InstallController.cs
@@ -16,15 +16,10 @@ namespace Hood.BaseControllers
     public class InstallController : Controller
     {
         private readonly IHostApplicationLifetime _applicationLifetime;
-        private readonly IConfiguration _config;
 
-        public InstallController(
-            IHostApplicationLifetime applicationLifetime,
-            IConfiguration config
-        )
+        public InstallController(IHostApplicationLifetime applicationLifetime)
         {
             _applicationLifetime = applicationLifetime;
-            _config = config;
         }
 
         [HttpGet]

--- a/projects/Hood.Core/Contexts/HoodDbContext.cs
+++ b/projects/Hood.Core/Contexts/HoodDbContext.cs
@@ -98,7 +98,8 @@ namespace Hood.Models
         {
             try
             {
-                Option option = await Options.FirstOrDefaultAsync();
+                // Probe read — succeeds only when the database/tables exist.
+                await Options.FirstOrDefaultAsync();
             }
             catch (SqlException ex)
             {
@@ -506,7 +507,7 @@ namespace Hood.Models
 
                         // ExecuteSql (FormattableString) parameterises the interpolated values
                         // automatically — replaces the deprecated ExecuteSqlRaw (HOOD-48 #3).
-                        int affectedRows = Database.ExecuteSql(
+                        Database.ExecuteSql(
                             $"UPDATE HoodMedia SET DirectoryId = {propertyDir.Id} WHERE DirectoryId IS NULL AND Directory = 'Property'"
                         );
 
@@ -519,12 +520,12 @@ namespace Hood.Models
                             // Bug fix (HOOD-48 #3): the old raw SQL had '@Directory' quoted as a string
                             // literal, so the parameter was never substituted and only 'Property' media
                             // was ever re-pointed. Interpolation makes type.TypeName a real parameter.
-                            affectedRows = Database.ExecuteSql(
+                            Database.ExecuteSql(
                                 $"UPDATE HoodMedia SET DirectoryId = {contentDir.Id} WHERE DirectoryId IS NULL AND Directory = {type.TypeName}"
                             );
                         }
 
-                        affectedRows = Database.ExecuteSql(
+                        Database.ExecuteSql(
                             $"UPDATE HoodMedia SET DirectoryId = {defaultDir.Id} WHERE DirectoryId IS NULL"
                         );
                     }

--- a/projects/Hood.Core/Contexts/IdentityContext.cs
+++ b/projects/Hood.Core/Contexts/IdentityContext.cs
@@ -88,7 +88,7 @@ namespace Hood.Contexts
                     var keygen = new KeyGenerator();
                     var password = keygen.Generate(16);
 
-                    IdentityResult ir = await repo.CreateAsync(userToInsert, password);
+                    await repo.CreateAsync(userToInsert, password);
 
                     var tempPasswordFile =
                         Engine.Services.Resolve<IWebHostEnvironment>().ContentRootPath

--- a/projects/Hood.Core/Engine.cs
+++ b/projects/Hood.Core/Engine.cs
@@ -164,7 +164,7 @@ namespace Hood.Core
         }
 
         /// <summary>
-        /// Gets the current resolvable version of the IMediaManager<MediaObject>.
+        /// Gets the current resolvable version of the IMediaManager service.
         /// </summary>
         public static IMediaManager Media
         {

--- a/projects/Hood.Core/Extensions/ClaimsPrincipalExtensions.cs
+++ b/projects/Hood.Core/Extensions/ClaimsPrincipalExtensions.cs
@@ -138,8 +138,6 @@ namespace Hood.Extensions
             }
             bool anonymous = principal.IsAnonymous();
             string displayName = principal.GetClaimValue(Constants.Identity.ClaimTypes.Nickname);
-            string firstName = principal.GetClaimValue(ClaimTypes.GivenName);
-            string lastName = principal.GetClaimValue(ClaimTypes.Surname);
 
             if (anonymous && allowAnonymous)
                 return "Anonymous";
@@ -165,8 +163,6 @@ namespace Hood.Extensions
             {
                 throw new ArgumentNullException(nameof(principal));
             }
-            bool anonymous = principal.IsAnonymous();
-            string displayName = principal.GetClaimValue(Constants.Identity.ClaimTypes.Nickname);
             string firstName = principal.GetClaimValue(ClaimTypes.GivenName);
             string lastName = principal.GetClaimValue(ClaimTypes.Surname);
             string email = principal.GetClaimValue(ClaimTypes.Email);

--- a/projects/Hood.Core/Extensions/EnumerableExtensions.cs
+++ b/projects/Hood.Core/Extensions/EnumerableExtensions.cs
@@ -26,15 +26,7 @@ namespace Hood.Extensions
 
         public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source)
         {
-            return source.OrderBy(x => Guid.NewGuid());
-        }
-
-        private delegate Func<A, R> Recursive<A, R>(Recursive<A, R> r);
-
-        private static Func<A, R> Y<A, R>(Func<Func<A, R>, Func<A, R>> f)
-        {
-            Recursive<A, R> rec = r => a => f(r(r))(a);
-            return rec(rec);
+            return source.OrderBy(_ => Guid.NewGuid());
         }
     }
 }

--- a/projects/Hood.Core/Extensions/HtmlHelperExtensions.cs
+++ b/projects/Hood.Core/Extensions/HtmlHelperExtensions.cs
@@ -24,6 +24,7 @@ namespace Hood.Extensions
             }
         }
 
+        // ReSharper disable once UnusedParameter.Global — extension receiver, required for @Html.X() / Url.X() call syntax.
         public static void AddInlineScript(
             this IHtmlHelper html,
             ResourceLocation location,
@@ -34,6 +35,7 @@ namespace Hood.Extensions
             pageBuilder.AddInlineScript(location, script);
         }
 
+        // ReSharper disable once UnusedParameter.Global — extension receiver, required for @Html.X() / Url.X() call syntax.
         public static void AddScript(
             this IHtmlHelper html,
             ResourceLocation location,
@@ -47,6 +49,7 @@ namespace Hood.Extensions
             pageBuilder.AddScript(location, src, bundle, isAsync, isDefer);
         }
 
+        // ReSharper disable once UnusedParameter.Global — extension receiver, required for @Html.X() / Url.X() call syntax.
         public static IHtmlContent RenderScripts(
             this IHtmlHelper html,
             IUrlHelper urlHelper,
@@ -58,18 +61,19 @@ namespace Hood.Extensions
             return new HtmlString(pageBuilder.GenerateScripts(urlHelper, location, bundleFiles));
         }
 
+        // ReSharper disable once UnusedParameter.Global — extension receiver, required for @Html.X() / Url.X() call syntax.
         public static IHtmlContent RenderInlineScripts(
             this IHtmlHelper html,
-            IUrlHelper urlHelper,
             ResourceLocation location
         )
         {
             var pageBuilder = Engine.Services.Resolve<IPageBuilder>();
-            return new HtmlString(pageBuilder.GenerateInlineScripts(urlHelper, location));
+            return new HtmlString(pageBuilder.GenerateInlineScripts(location));
         }
 
         #endregion
 
+        // ReSharper disable once UnusedParameter.Global — extension receiver, required for @Html.X() / Url.X() call syntax.
         public static IHtmlContent RenderHoneypotField<TModel>(this IHtmlHelper<TModel> html)
             where TModel : SpamPreventionModel
         {

--- a/projects/Hood.Core/Extensions/IFormFileExtensions.cs
+++ b/projects/Hood.Core/Extensions/IFormFileExtensions.cs
@@ -6,8 +6,6 @@ namespace Hood.Extensions
 {
     public static class IFormFileExtensions
     {
-        private const int Megabyte = 1048576;
-
         public static string GetFilename(this IFormFile file)
         {
             string filename = ContentDispositionHeaderValue

--- a/projects/Hood.Core/Extensions/ObjectExtensions.cs
+++ b/projects/Hood.Core/Extensions/ObjectExtensions.cs
@@ -18,6 +18,7 @@ namespace Hood.Extensions
         /// </summary>
         /// <param name="source">The source.</param>
         /// <param name="destination">The destination.</param>
+        /// <param name="allowedKeys">The form keys that are allowed to be copied.</param>
         public static T UpdateFromFormModel<T, TSource>(
             this T destination,
             TSource source,
@@ -87,7 +88,6 @@ namespace Hood.Extensions
         /// Will return a string representation of the object and all it's child members. In JSON format.
         /// </summary>
         /// <param name="element">The object or class you want to print to JSON.</param>
-        /// <param name="indentSize">The number of tab characters inserted onto each sub line.</param>
         /// <returns>String Json content</returns>
         public static string ToJson(this object element)
         {
@@ -113,11 +113,10 @@ namespace Hood.Extensions
         }
 
         /// <summary>
-        /// Will return a string representation of the object and all it's child members. In JSON format.
+        /// Returns a cache key for the entity — its JSON-serialised representation.
         /// </summary>
-        /// <param name="element">The object or class you want to print to JSON.</param>
-        /// <param name="indentSize">The number of tab characters inserted onto each sub line.</param>
-        /// <returns>String Json content</returns>
+        /// <param name="element">The entity to generate a cache key for.</param>
+        /// <returns>String cache key</returns>
         public static string GetCacheKey(this BaseEntity element)
         {
             try
@@ -135,6 +134,7 @@ namespace Hood.Extensions
         /// </summary>
         /// <param name="source">The source.</param>
         /// <param name="destination">The destination.</param>
+        /// <param name="updateOnly">When true, only set properties whose value has changed.</param>
         public static void CopyProperties(
             this object source,
             object destination,

--- a/projects/Hood.Core/Extensions/StringExtensions.cs
+++ b/projects/Hood.Core/Extensions/StringExtensions.cs
@@ -14,7 +14,7 @@ namespace Hood.Extensions
 
         public static bool IsAbsoluteUrl(this string url)
         {
-            return Uri.TryCreate(url, UriKind.Absolute, out Uri result);
+            return Uri.TryCreate(url, UriKind.Absolute, out _);
         }
 
         public static bool IsValidEmail(this string email)

--- a/projects/Hood.Core/Extensions/StringExtensions.cs
+++ b/projects/Hood.Core/Extensions/StringExtensions.cs
@@ -74,11 +74,9 @@ namespace Hood.Extensions
 
         public static string ToUrl(this string url)
         {
-            Uri formattedUrl = null;
             try
             {
-                formattedUrl = new UriBuilder(url).Uri;
-                return formattedUrl.ToString();
+                return new UriBuilder(url).Uri.ToString();
             }
             catch (ArgumentNullException)
             {

--- a/projects/Hood.Core/Extensions/StringExtensions.cs
+++ b/projects/Hood.Core/Extensions/StringExtensions.cs
@@ -451,7 +451,7 @@ namespace Hood.Extensions
                         if (!quoted)
                         {
                             sb.AppendLine();
-                            Enumerable.Range(0, ++indent).ForEach(item => sb.Append(indentString));
+                            Enumerable.Range(0, ++indent).ForEach(_ => sb.Append(indentString));
                         }
                         break;
                     case '}':
@@ -459,7 +459,7 @@ namespace Hood.Extensions
                         if (!quoted)
                         {
                             sb.AppendLine();
-                            Enumerable.Range(0, --indent).ForEach(item => sb.Append(indentString));
+                            Enumerable.Range(0, --indent).ForEach(_ => sb.Append(indentString));
                         }
                         sb.Append(ch);
                         break;
@@ -483,7 +483,7 @@ namespace Hood.Extensions
                         if (!quoted)
                         {
                             sb.AppendLine();
-                            Enumerable.Range(0, indent).ForEach(item => sb.Append(indentString));
+                            Enumerable.Range(0, indent).ForEach(_ => sb.Append(indentString));
                         }
                         break;
                     case ':':

--- a/projects/Hood.Core/Extensions/TypeExtensions.cs
+++ b/projects/Hood.Core/Extensions/TypeExtensions.cs
@@ -15,12 +15,7 @@ namespace Hood.Extensions
             try
             {
                 var genericType = inherited.GetGenericTypeDefinition();
-                foreach (
-                    var implementedInterface in type.FindInterfaces(
-                        (objType, objCriteria) => true,
-                        null
-                    )
-                )
+                foreach (var implementedInterface in type.FindInterfaces((_, _) => true, null))
                 {
                     if (!implementedInterface.IsGenericType)
                         continue;

--- a/projects/Hood.Core/Extensions/UrlExtensions.cs
+++ b/projects/Hood.Core/Extensions/UrlExtensions.cs
@@ -16,11 +16,7 @@ namespace Hood.Extensions
             HttpContextAccessor = httpContextAccessor;
         }
 
-        public static Uri AddParameterToUrl(
-            this string url,
-            Dictionary<string, string> parameters,
-            bool relative = true
-        )
+        public static Uri AddParameterToUrl(this string url, Dictionary<string, string> parameters)
         {
             var uriBuilder = new UriBuilder(url);
             var uri = uriBuilder.Uri;
@@ -93,6 +89,7 @@ namespace Hood.Extensions
         /// <param name="url">The Url Helper class.</param>
         /// <param name="slug">The url slug, ommitting the first / - i.e. http://xxx.com/test/test would be test/test/</param>
         /// <returns></returns>
+        // ReSharper disable once UnusedParameter.Global — extension receiver, required for @Html.X() / Url.X() call syntax.
         public static string AbsoluteUrl(this IUrlHelper url, string slug = "")
         {
             var request = HttpContextAccessor.HttpContext.Request;

--- a/projects/Hood.Core/Filters/InstalledAttribute.cs
+++ b/projects/Hood.Core/Filters/InstalledAttribute.cs
@@ -15,7 +15,7 @@ namespace Hood.Filters
             ActionExecutionDelegate next
         )
         {
-            if (!Engine.Services.Installed)
+            if (!Engine.Services.Installed || !Engine.Services.Seeded)
             {
                 context.Result = new RedirectToRouteResult(
                     new RouteValueDictionary(new { controller = "Install", action = "Install" })

--- a/projects/Hood.Core/HoodConfiguration.cs
+++ b/projects/Hood.Core/HoodConfiguration.cs
@@ -30,8 +30,6 @@ namespace Hood.Core
 
     public class Auth0Configuration
     {
-        public Auth0Configuration() { }
-
         public string Domain { get; set; }
         public string ClientId { get; set; }
         public string ClientSecret { get; set; }

--- a/projects/Hood.Core/Interfaces/IHoodComponent.cs
+++ b/projects/Hood.Core/Interfaces/IHoodComponent.cs
@@ -18,6 +18,7 @@ namespace Hood.Interfaces
         /// </summary>
         /// <param name="services">Services collection</param>
         /// <param name="config">Application configuration</param>
+        // ReSharper disable once UnusedParameter.Global — plugin hook contract; components may ignore the configuration.
         void ConfigureServices(IServiceCollection services, IConfiguration config);
 
         /// <summary>

--- a/projects/Hood.Core/Interfaces/IHoodComponent.cs
+++ b/projects/Hood.Core/Interfaces/IHoodComponent.cs
@@ -16,7 +16,8 @@ namespace Hood.Interfaces
         /// <summary>
         /// Register services and interfaces
         /// </summary>
-        /// <param name="builder">Services collection</param>
+        /// <param name="services">Services collection</param>
+        /// <param name="config">Application configuration</param>
         void ConfigureServices(IServiceCollection services, IConfiguration config);
 
         /// <summary>
@@ -25,9 +26,11 @@ namespace Hood.Interfaces
         int ServiceConfigurationOrder { get; }
 
         /// <summary>
-        /// Register services and interfaces
+        /// Configure the application pipeline for this component
         /// </summary>
-        /// <param name="builder">Services collection</param>
+        /// <param name="app">Application builder</param>
+        /// <param name="env">Hosting environment</param>
+        /// <param name="config">Application configuration</param>
         void Configure(IApplicationBuilder app, IWebHostEnvironment env, IConfiguration config);
     }
 }

--- a/projects/Hood.Core/Models/ComplexTypes/Country.cs
+++ b/projects/Hood.Core/Models/ComplexTypes/Country.cs
@@ -86,7 +86,7 @@ namespace Hood.Models
         )
         {
             Iso2 = iso2;
-            Iso3 = iso2;
+            Iso3 = iso3;
             IsoNumeric = numeric;
             Name = name;
             FullName = fullName;

--- a/projects/Hood.Core/Models/ComplexTypes/Country.cs
+++ b/projects/Hood.Core/Models/ComplexTypes/Country.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -70,11 +71,7 @@ namespace Hood.Models
                     "TR",
                     "GB",
                 };
-                europe.ForEach(e => e = e.ToLower());
-                if (europe.Contains(Iso2.ToLower()))
-                    return true;
-                else
-                    return false;
+                return europe.Contains(Iso2, StringComparer.OrdinalIgnoreCase);
             }
         }
 

--- a/projects/Hood.Core/Models/Content/ContentMetadata.cs
+++ b/projects/Hood.Core/Models/Content/ContentMetadata.cs
@@ -6,8 +6,6 @@ namespace Hood.Models
 {
     public class ContentMeta : MetadataBase
     {
-        public ContentMeta() { }
-
         public int ContentId { get; set; }
 
         [JsonIgnore]

--- a/projects/Hood.Core/Models/Email/MailObject.cs
+++ b/projects/Hood.Core/Models/Email/MailObject.cs
@@ -101,7 +101,6 @@ namespace Hood.Models
 
         public MailObject()
         {
-            BasicSettings basicSettings = Engine.Settings.Basic;
             MailSettings mailSettings = Engine.Settings.Mail;
 
             _textBody = new StringWriter();

--- a/projects/Hood.Core/Models/Identity/UserProfile.cs
+++ b/projects/Hood.Core/Models/Identity/UserProfile.cs
@@ -42,10 +42,7 @@ namespace Hood.Models
         public bool PhoneNumberConfirmed { get; set; }
     }
 
-    public class UserProfile : UserProfileBase
-    {
-        public UserProfile() { }
-    }
+    public class UserProfile : UserProfileBase { }
 
     public class UserProfileBase : IUserProfile
     {

--- a/projects/Hood.Core/Models/Metadata/MetadataBase.cs
+++ b/projects/Hood.Core/Models/Metadata/MetadataBase.cs
@@ -8,8 +8,6 @@ namespace Hood.Models
 {
     public abstract class MetadataBase : BaseEntity, IMetadata
     {
-        public MetadataBase() { }
-
         public string BaseValue { get; internal set; }
         public string Name { get; set; }
         public string Type { get; set; }

--- a/projects/Hood.Core/Models/Property/PropertyMetadata.cs
+++ b/projects/Hood.Core/Models/Property/PropertyMetadata.cs
@@ -5,8 +5,6 @@ namespace Hood.Models
 {
     public class PropertyMeta : MetadataBase
     {
-        public PropertyMeta() { }
-
         public int PropertyId { get; set; }
 
         [JsonIgnore]

--- a/projects/Hood.Core/Routing/PagesRouteConstraint.cs
+++ b/projects/Hood.Core/Routing/PagesRouteConstraint.cs
@@ -9,8 +9,6 @@ namespace Hood.Core
 {
     public class PagesRouteConstraint : IRouteConstraint
     {
-        private readonly object codeLock = new Object();
-
         public bool Match(
             HttpContext httpContext,
             IRouter route,

--- a/projects/Hood.Core/ServiceProvider/HoodServiceProvider.cs
+++ b/projects/Hood.Core/ServiceProvider/HoodServiceProvider.cs
@@ -82,12 +82,8 @@ namespace Hood.Core
             // (TLS 1.2+ is the runtime/OS default on net10 and ServicePointManager no longer
             // affects HttpClient, so the old ServicePointManager.SecurityProtocol set is removed.)
 
-            //set base application path
-            var provider = services.BuildServiceProvider();
-            var hostingEnvironment = provider.GetRequiredService<IWebHostEnvironment>();
-
             //initialize plugins
-            var mvcCoreBuilder = services.AddMvcCore();
+            services.AddMvcCore();
         }
 
         public T Resolve<T>()

--- a/projects/Hood.Core/ServiceProvider/HoodServiceProvider.cs
+++ b/projects/Hood.Core/ServiceProvider/HoodServiceProvider.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Hood.Enums;
 using Hood.Interfaces;
 using Hood.Services;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/projects/Hood.Core/ServiceProvider/HoodServiceProvider.cs
+++ b/projects/Hood.Core/ServiceProvider/HoodServiceProvider.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using Hood.Enums;
 using Hood.Interfaces;
+using Hood.Models;
 using Hood.Services;
 using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -21,6 +23,38 @@ namespace Hood.Core
         public bool Installed
         {
             get { return !StartupExceptions.Any(); }
+        }
+
+        private bool _seeded;
+        public bool Seeded
+        {
+            get
+            {
+                if (_seeded)
+                {
+                    return true;
+                }
+                if (!Installed)
+                {
+                    return false;
+                }
+                try
+                {
+                    // The install flow's Seed() writes the SiteOwner option — its presence is the
+                    // marker that settings/owner have been seeded. Sticky once true; the install
+                    // flow restarts the host after seeding, so this re-evaluates exactly once.
+                    var config = Resolve<IConfiguration>();
+                    var options = new DbContextOptionsBuilder<HoodDbContext>();
+                    options.UseSqlServer(config["ConnectionStrings:DefaultConnection"]);
+                    using var db = new HoodDbContext(options.Options);
+                    _seeded = db.Options.Any(o => o.Id == "Hood.Settings.SiteOwner");
+                    return _seeded;
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+            }
         }
 
         public List<StartupException> GetStartupExceptionsByType(StartupError type)

--- a/projects/Hood.Core/ServiceProvider/IHoodServiceProvider.cs
+++ b/projects/Hood.Core/ServiceProvider/IHoodServiceProvider.cs
@@ -16,6 +16,12 @@ namespace Hood.Core
 
         bool Installed { get; }
 
+        /// <summary>
+        /// True once the database has been seeded by the install flow (site owner + default
+        /// settings present). A schema-complete but unseeded database is Installed but not Seeded.
+        /// </summary>
+        bool Seeded { get; }
+
         List<StartupException> GetStartupExceptionsByType(StartupError type);
 
         /// <summary>

--- a/projects/Hood.Core/Services/AccountRepository/AccountRepository.cs
+++ b/projects/Hood.Core/Services/AccountRepository/AccountRepository.cs
@@ -32,8 +32,6 @@ namespace Hood.Services
         }
         private UserManager<ApplicationUser> UserManager =>
             Engine.Services.Resolve<UserManager<ApplicationUser>>();
-        private RoleManager<IdentityRole> RoleManager =>
-            Engine.Services.Resolve<RoleManager<IdentityRole>>();
 
         public AccountRepository()
         {

--- a/projects/Hood.Core/Services/AccountRepository/Auth0AccountRepository.cs
+++ b/projects/Hood.Core/Services/AccountRepository/Auth0AccountRepository.cs
@@ -180,7 +180,6 @@ namespace Hood.Services
             string picture
         )
         {
-            var authProviderName = fullAuthUserId.Split('|')[0];
             var authUserId = fullAuthUserId.Split('|')[1];
             Auth0.ManagementApi.Models.User newAuthUser = null;
             try

--- a/projects/Hood.Core/Services/AddressService/AddressService.cs
+++ b/projects/Hood.Core/Services/AddressService/AddressService.cs
@@ -10,8 +10,6 @@ namespace Hood.Services
 {
     public class AddressService : IAddressService
     {
-        public AddressService() { }
-
         public GoogleAddress GeocodeAddress(IAddress address)
         {
             var key = Engine.Settings.Integrations.GoogleMapsApiKey;

--- a/projects/Hood.Core/Services/Auth0LoginService/Auth0LoginService.cs
+++ b/projects/Hood.Core/Services/Auth0LoginService/Auth0LoginService.cs
@@ -81,7 +81,7 @@ namespace Hood.Services
 
             var principal = e.Principal;
             var userId = e.Principal.GetUserId();
-            var returnUrl = e.ReturnUri;
+            string returnUrl;
 
             var identity = (ClaimsIdentity)principal.Identity;
 

--- a/projects/Hood.Core/Services/Auth0LoginService/IAuth0LoginService.cs
+++ b/projects/Hood.Core/Services/Auth0LoginService/IAuth0LoginService.cs
@@ -26,6 +26,10 @@ namespace Hood.Services
 #nullable disable
 
         OpenIdConnectEvents AsOpenIdConnectEvents();
+
+        // OIDC event hook contract — the context parameter is part of the callback shape
+        // whether or not the default implementation reads it.
+        // ReSharper disable UnusedParameter.Global
         Task OnAccessDenied(AccessDeniedContext e);
         Task OnAuthenticationFailed(AuthenticationFailedContext e);
         Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedContext e);
@@ -38,6 +42,8 @@ namespace Hood.Services
         Task OnTicketReceived(TicketReceivedContext e);
         Task OnTokenResponseReceived(TokenResponseReceivedContext e);
         Task OnTokenValidated(TokenValidatedContext e);
+
+        // ReSharper restore UnusedParameter.Global
         Task OnUserInformationReceived(UserInformationReceivedContext e);
     }
 }

--- a/projects/Hood.Core/Services/Auth0Service/Auth0Service.cs
+++ b/projects/Hood.Core/Services/Auth0Service/Auth0Service.cs
@@ -151,7 +151,7 @@ namespace Hood.Services
             var authProviderName = fullAuthUserId.Split('|')[0];
             var authUserId = fullAuthUserId.Split('|')[1];
             var client = await GetClientAsync();
-            var response = await client.Users.LinkAccountAsync(
+            await client.Users.LinkAccountAsync(
                 primaryAccount.Id,
                 new UserAccountLinkRequest() { Provider = authProviderName, UserId = authUserId }
             );
@@ -163,7 +163,7 @@ namespace Hood.Services
         )
         {
             var client = await GetClientAsync();
-            var response = await client.Users.UnlinkAccountAsync(
+            await client.Users.UnlinkAccountAsync(
                 primaryAccount.Id,
                 identityToDisconnect.Provider,
                 identityToDisconnect.LocalUserId

--- a/projects/Hood.Core/Services/Caching/ContentByTypeCache.cs
+++ b/projects/Hood.Core/Services/Caching/ContentByTypeCache.cs
@@ -26,6 +26,8 @@ namespace Hood.Caching
                 ResetCache();
             };
             _events.ContentChanged += resetContentByTypeCache;
+            // Settings saves must rebuild the type-keyed cache too (HOOD-82).
+            _events.OptionsChanged += resetContentByTypeCache;
             ResetCache();
         }
 
@@ -46,6 +48,11 @@ namespace Hood.Caching
 
             ContentSettings contentSettings = Engine.Settings.Content;
             bySlug = new Dictionary<string, Lazy<Dictionary<int, Content>>>();
+            if (contentSettings?.Types == null)
+            {
+                // Unseeded database — empty cache; install gate handles routing (HOOD-81).
+                return;
+            }
             foreach (var type in contentSettings.Types.Where(t => t.Enabled && t.CachedByType))
             {
                 bySlug.Add(

--- a/projects/Hood.Core/Services/Caching/ContentByTypeCache.cs
+++ b/projects/Hood.Core/Services/Caching/ContentByTypeCache.cs
@@ -15,19 +15,13 @@ namespace Hood.Caching
         private readonly IConfiguration _config;
 
         private Dictionary<string, Lazy<Dictionary<int, Content>>> bySlug;
-        private readonly ContentCategoryCache _categories;
         private readonly IEventsService _events;
 
-        public ContentByTypeCache(
-            IConfiguration config,
-            ContentCategoryCache categories,
-            IEventsService events
-        )
+        public ContentByTypeCache(IConfiguration config, IEventsService events)
         {
             _config = config;
-            _categories = categories;
             _events = events;
-            EventHandler<EventArgs> resetContentByTypeCache = (sender, eventArgs) =>
+            EventHandler<EventArgs> resetContentByTypeCache = (_, _) =>
             {
                 ResetCache();
             };

--- a/projects/Hood.Core/Services/Caching/ContentCategoryCache.cs
+++ b/projects/Hood.Core/Services/Caching/ContentCategoryCache.cs
@@ -242,7 +242,6 @@ namespace Hood.Caching
 
         public IHtmlContent AdminContentCategoryTree(
             IEnumerable<ContentCategory> startLevel,
-            string contentType,
             List<string> categoriesSelected,
             int startingLevel = 0
         )
@@ -297,7 +296,6 @@ namespace Hood.Caching
 
                     htmlOutput += AdminContentCategoryTree(
                         category.Children,
-                        contentType,
                         categoriesSelected,
                         startingLevel + 1
                     );

--- a/projects/Hood.Core/Services/Caching/ContentCategoryCache.cs
+++ b/projects/Hood.Core/Services/Caching/ContentCategoryCache.cs
@@ -28,6 +28,9 @@ namespace Hood.Caching
                 ResetCache();
             };
             events.ContentChanged += resetContentByTypeCache;
+            // Settings saves (e.g. enabling a content type) must also rebuild the type-keyed
+            // dictionaries, or newly-enabled types 500 until an app restart (HOOD-82).
+            events.OptionsChanged += resetContentByTypeCache;
             ResetCache();
         }
 
@@ -48,7 +51,7 @@ namespace Hood.Caching
         public int Count(string type)
         {
             if (type.IsSet())
-                return bySlug[type].Value.Count;
+                return bySlug.TryGetValue(type, out var categories) ? categories.Value.Count : 0;
             else
                 return byKey.Value.Count;
         }
@@ -84,6 +87,13 @@ namespace Hood.Caching
 
             ContentSettings contentSettings = Engine.Settings.Content;
             bySlug = new Dictionary<string, Lazy<Dictionary<string, ContentCategory>>>();
+            if (contentSettings?.Types == null)
+            {
+                // Schema-complete but unseeded database (pre-install) — leave the caches empty
+                // rather than throwing; the install gate routes traffic to /install (HOOD-81).
+                topLevel = new Lazy<ContentCategory[]>(Array.Empty<ContentCategory>);
+                return;
+            }
             foreach (var type in contentSettings.Types.Where(t => t.Enabled))
             {
                 bySlug.Add(
@@ -157,7 +167,9 @@ namespace Hood.Caching
 
         public IEnumerable<ContentCategory> GetSuggestions(string type)
         {
-            return bySlug[type].Value.Values;
+            return bySlug.TryGetValue(type, out var categories)
+                ? categories.Value.Values
+                : Enumerable.Empty<ContentCategory>();
         }
 
         // Html

--- a/projects/Hood.Core/Services/Caching/ContentCategoryCache.cs
+++ b/projects/Hood.Core/Services/Caching/ContentCategoryCache.cs
@@ -23,7 +23,7 @@ namespace Hood.Caching
         public ContentCategoryCache(IConfiguration config, IEventsService events)
         {
             _config = config;
-            EventHandler<EventArgs> resetContentByTypeCache = (sender, eventArgs) =>
+            EventHandler<EventArgs> resetContentByTypeCache = (_, _) =>
             {
                 ResetCache();
             };

--- a/projects/Hood.Core/Services/Caching/HoodRedisCache.cs
+++ b/projects/Hood.Core/Services/Caching/HoodRedisCache.cs
@@ -79,6 +79,7 @@ namespace Hood.Caching
             await Database.KeyDeleteAsync(key);
         }
 
+        // ReSharper disable once UnusedParameter.Global — IHoodCache contract; this Redis implementation is not implemented yet.
         public void RemoveByType(Type type)
         {
             throw new NotImplementedException();

--- a/projects/Hood.Core/Services/ContentRepository/ContentRepository.cs
+++ b/projects/Hood.Core/Services/ContentRepository/ContentRepository.cs
@@ -236,11 +236,7 @@ namespace Hood.Services
             return content;
         }
 
-        public async Task<Content> GetContentByIdAsync(
-            int id,
-            bool clearCache = false,
-            bool track = true
-        )
+        public async Task<Content> GetContentByIdAsync(int id, bool clearCache = false)
         {
             string cacheKey = typeof(Content) + ".Single." + id;
             if (!_cache.TryGetValue(cacheKey, out Content content) || clearCache)
@@ -262,11 +258,7 @@ namespace Hood.Services
             return content;
         }
 
-        public async Task<ContentView> GetContentViewByIdAsync(
-            int id,
-            bool clearCache = false,
-            bool track = true
-        )
+        public async Task<ContentView> GetContentViewByIdAsync(int id, bool clearCache = false)
         {
             string cacheKey = typeof(ContentView) + ".Single." + id;
             if (!_cache.TryGetValue(cacheKey, out ContentView content) || clearCache)

--- a/projects/Hood.Core/Services/ContentRepository/ContentRepository.cs
+++ b/projects/Hood.Core/Services/ContentRepository/ContentRepository.cs
@@ -25,13 +25,11 @@ namespace Hood.Services
         private readonly HoodDbContext _hoodDb;
         private readonly IHoodCache _cache;
         private readonly IEventsService _eventService;
-        private readonly IWebHostEnvironment _env;
 
         public ContentRepository(
             ContentContext db,
             HoodDbContext hoodDb,
             IHoodCache cache,
-            IWebHostEnvironment env,
             IEventsService eventService
         )
         {
@@ -39,7 +37,6 @@ namespace Hood.Services
             _hoodDb = hoodDb;
             _cache = cache;
             _eventService = eventService;
-            _env = env;
         }
 
         #region Content CRUD

--- a/projects/Hood.Core/Services/ContentRepository/IContentRepository.cs
+++ b/projects/Hood.Core/Services/ContentRepository/IContentRepository.cs
@@ -21,12 +21,8 @@ namespace Hood.Services
         Task<IEnumerable<ContentCategory>> GetCategoriesAsync(int contentId);
         Task<ContentCategory> GetCategoryByIdAsync(int categoryId);
         Task<ContentModel> GetContentAsync(ContentModel model);
-        Task<Content> GetContentByIdAsync(int id, bool clearCache = false, bool track = true);
-        Task<ContentView> GetContentViewByIdAsync(
-            int id,
-            bool clearCache = false,
-            bool track = true
-        );
+        Task<Content> GetContentByIdAsync(int id, bool clearCache = false);
+        Task<ContentView> GetContentViewByIdAsync(int id, bool clearCache = false);
         Task<MediaDirectory> GetDirectoryAsync();
         Task<ContentModel> GetFeaturedAsync(string type, string category = null, int pageSize = 5);
         List<string> GetMetasForTemplate(string templateName, string folder);

--- a/projects/Hood.Core/Services/EmailSender/EmailSender.cs
+++ b/projects/Hood.Core/Services/EmailSender/EmailSender.cs
@@ -69,7 +69,6 @@ namespace Hood.Services
             );
             msg.ReplyTo = replyTo;
             var response = await client.SendEmailAsync(msg);
-            var body = await response.DeserializeResponseBodyAsync(response.Body);
             if (
                 response.StatusCode == HttpStatusCode.Accepted
                 || response.StatusCode == HttpStatusCode.OK
@@ -112,7 +111,6 @@ namespace Hood.Services
                 );
                 msg.ReplyTo = replyTo;
                 var response = await client.SendEmailAsync(msg);
-                var body = await response.DeserializeResponseBodyAsync(response.Body);
                 if (
                     response.StatusCode == HttpStatusCode.Accepted
                     || response.StatusCode == HttpStatusCode.OK

--- a/projects/Hood.Core/Services/FTPService/FTPService.cs
+++ b/projects/Hood.Core/Services/FTPService/FTPService.cs
@@ -83,7 +83,7 @@ namespace Hood.Services
         // iterate through every registered user, and send them a copy of the email.
         private void GetFile(object data)
         {
-            bool cancelled = false;
+            bool cancelled;
             // Unpack the parameter objects.
             object[] parameters = (object[])data;
             string server = (string)parameters[0];
@@ -101,7 +101,7 @@ namespace Hood.Services
             {
                 FtpWebResponse response = null;
                 FileStream outputStream = null;
-                Stream ftpStream = null;
+                Stream ftpStream;
                 try
                 {
                     // Set the Total to 0, starting point.
@@ -130,8 +130,7 @@ namespace Hood.Services
                     StatusMessage = "Downloading file, " + filename + "...";
                     Lock.ReleaseWriterLock();
 
-                    int readCount = 0;
-                    readCount = ftpStream.Read(Buffer, 0, BufferSize);
+                    int readCount = ftpStream.Read(Buffer, 0, BufferSize);
                     BytesTransferred += readCount;
                     while (readCount > 0)
                     {

--- a/projects/Hood.Core/Services/KeyGenerator/KeyGenerator.cs
+++ b/projects/Hood.Core/Services/KeyGenerator/KeyGenerator.cs
@@ -346,7 +346,7 @@ namespace Hood.Services
                 throw new ArgumentException(
                     "There is not enough characters to create a string without repeats"
                 );
-            string result = ""; // This string will contain the result
+            string result; // This string will contain the result
             if (PatternDriven)
             {
                 // Using the pattern to generate a string
@@ -384,7 +384,7 @@ namespace Hood.Services
             List<char> Characters = new List<char>();
             foreach (char character in Pattern.ToCharArray())
             {
-                char newChar = ' ';
+                char newChar;
                 switch (character)
                 {
                     case 'L':
@@ -563,7 +563,7 @@ namespace Hood.Services
         /// <returns>A random character from the array</returns>
         private char GetRandomCharFromArray(char[] array, List<char> existentItems)
         {
-            char Character = ' ';
+            char Character;
             do
             {
                 Character = array[GetRandomInt() % array.Length];

--- a/projects/Hood.Core/Services/LogService/ILogService.cs
+++ b/projects/Hood.Core/Services/LogService/ILogService.cs
@@ -6,12 +6,15 @@ namespace Hood.Services
 {
     public interface ILogService
     {
+        // ReSharper disable once UnusedParameter.Global — logging payload contract; the default sink doesn't persist it yet.
         Task AddLogAsync<TSource>(
             string message,
             object logObject = null,
             LogType type = LogType.Info
         );
         Task AddExceptionAsync<TSource>(string message, Exception ex, LogType type = LogType.Error);
+
+        // ReSharper disable once UnusedParameter.Global — logging payload contract; the default sink doesn't persist it yet.
         Task AddExceptionAsync<TSource>(
             string message,
             object logObject,

--- a/projects/Hood.Core/Services/LogService/LogService.cs
+++ b/projects/Hood.Core/Services/LogService/LogService.cs
@@ -9,8 +9,6 @@ namespace Hood.Services
 {
     public class LogService : ILogService
     {
-        public LogService() { }
-
         public Task AddLogAsync<TSource>(
             string message,
             object logObject = null,

--- a/projects/Hood.Core/Services/MediaManager/IMediaManager.cs
+++ b/projects/Hood.Core/Services/MediaManager/IMediaManager.cs
@@ -21,8 +21,8 @@ namespace Hood.Services
         /// Gets a safe filename for use with Azure storage. Unsafe characters will be removed.
         /// If the filename is already present, a number will be postfixed.
         /// </summary>
-        /// <param name="file">The filename. Filename will be calclulated from this.</param>
-        /// <param name="directory">The base path for the destination on Azure storage. In the form {0}/{1}/</param>
+        /// <param name="path">The base path for the destination on storage. In the form {0}/{1}/</param>
+        /// <param name="filename">The filename. The clean filename will be calculated from this.</param>
         /// <returns></returns>
         string GetCleanFilename(string path, string filename);
         Task<string> GetSafeFilename(string path, string filename);
@@ -30,8 +30,8 @@ namespace Hood.Services
         /// <summary>
         /// Uploads the specified IFormFile object to the Azure storage, at the location specified in the path parameter.
         /// </summary>
-        /// <param name="file">IFormFile object (Http File Request object)</param>
-        /// <param name="path">Path on Azure storage.</param>
+        /// <param name="file">The file stream to upload.</param>
+        /// <param name="blobReference">The blob reference (path) on Azure storage.</param>
         /// <returns></returns>
         Task<BlockBlobClient> Upload(Stream file, string blobReference);
 
@@ -77,7 +77,7 @@ namespace Hood.Services
         /// thumbnails will be processed, uploaded to Azure storage and placed into the IMediaItem.
         /// </summary>
         /// <param name="file">IFormFile object (Http File Request object)</param>
-        /// <param name="media">Object of type IMediaItem to contain the file information and details aqcuired in the upload process.</param>
+        /// <param name="directoryPath">The directory path on storage to upload into.</param>
         /// <returns></returns>
         Task<IMediaObject> ProcessUpload(IFormFile file, string directoryPath);
 
@@ -85,7 +85,11 @@ namespace Hood.Services
         /// Complete function to take an file stream and basic file data, check it's contents, add it's information to an IMediaItem object, if the file is an image,
         /// thumbnails will be processed, uploaded to Azure storage and placed into the IMediaItem.
         /// </summary>
-        /// <param name="media">Object of type IMediaItem to contain the file information and details aqcuired in the upload process.</param>
+        /// <param name="file">The file stream to upload.</param>
+        /// <param name="filename">The original filename.</param>
+        /// <param name="filetype">The content (MIME) type of the file.</param>
+        /// <param name="size">The file size in bytes.</param>
+        /// <param name="directoryPath">The directory path on storage to upload into.</param>
         /// <returns></returns>
         Task<IMediaObject> ProcessUpload(
             Stream file,

--- a/projects/Hood.Core/Services/MediaManager/IMediaManager.cs
+++ b/projects/Hood.Core/Services/MediaManager/IMediaManager.cs
@@ -21,10 +21,9 @@ namespace Hood.Services
         /// Gets a safe filename for use with Azure storage. Unsafe characters will be removed.
         /// If the filename is already present, a number will be postfixed.
         /// </summary>
-        /// <param name="path">The base path for the destination on storage. In the form {0}/{1}/</param>
         /// <param name="filename">The filename. The clean filename will be calculated from this.</param>
         /// <returns></returns>
-        string GetCleanFilename(string path, string filename);
+        string GetCleanFilename(string filename);
         Task<string> GetSafeFilename(string path, string filename);
 
         /// <summary>
@@ -88,14 +87,12 @@ namespace Hood.Services
         /// <param name="file">The file stream to upload.</param>
         /// <param name="filename">The original filename.</param>
         /// <param name="filetype">The content (MIME) type of the file.</param>
-        /// <param name="size">The file size in bytes.</param>
         /// <param name="directoryPath">The directory path on storage to upload into.</param>
         /// <returns></returns>
         Task<IMediaObject> ProcessUpload(
             Stream file,
             string filename,
             string filetype,
-            long size,
             string directoryPath
         );
 

--- a/projects/Hood.Core/Services/MediaManager/MediaManager.cs
+++ b/projects/Hood.Core/Services/MediaManager/MediaManager.cs
@@ -102,11 +102,9 @@ namespace Hood.Services
         public async Task<string> GetSafeFilename(string directory, string filename)
         {
             filename = Guid.NewGuid().ToString() + Path.GetExtension(filename);
-            int counter = 1;
             while (await Exists(directory, filename))
             {
                 filename = Guid.NewGuid().ToString() + Path.GetExtension(filename);
-                counter++;
             }
             return filename;
         }

--- a/projects/Hood.Core/Services/MediaManager/MediaManager.cs
+++ b/projects/Hood.Core/Services/MediaManager/MediaManager.cs
@@ -299,7 +299,7 @@ namespace Hood.Services
         {
             try
             {
-                string url = "";
+                string url;
 
                 string fileName = Path.GetFileNameWithoutExtension(media.Url);
                 string fileExt = Path.GetExtension(media.Url);

--- a/projects/Hood.Core/Services/MediaManager/MediaManager.cs
+++ b/projects/Hood.Core/Services/MediaManager/MediaManager.cs
@@ -10,7 +10,6 @@ using Hood.Enums;
 using Hood.Extensions;
 using Hood.Interfaces;
 using Hood.Models;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -107,7 +106,7 @@ namespace Hood.Services
             return filename;
         }
 
-        public string GetCleanFilename(string directory, string filename)
+        public string GetCleanFilename(string filename)
         {
             filename = filename.Trim(Path.GetInvalidFileNameChars());
             filename = filename.Trim(Path.GetInvalidPathChars());
@@ -235,7 +234,6 @@ namespace Hood.Services
             Stream file,
             string filename,
             string filetype,
-            long size,
             string directoryPath
         )
         {

--- a/projects/Hood.Core/Services/MediaManager/MediaManager.cs
+++ b/projects/Hood.Core/Services/MediaManager/MediaManager.cs
@@ -26,12 +26,10 @@ namespace Hood.Services
         private MediaSettings _mediaSettings;
         private string _container;
         private string _key;
-        private readonly IWebHostEnvironment _env;
         private readonly IConfiguration _config;
 
-        public MediaManager(IWebHostEnvironment env, IConfiguration config)
+        public MediaManager(IConfiguration config)
         {
-            _env = env;
             _config = config;
         }
 

--- a/projects/Hood.Core/Services/PageBuilder/IPageBuilder.cs
+++ b/projects/Hood.Core/Services/PageBuilder/IPageBuilder.cs
@@ -13,7 +13,7 @@ namespace Hood.Services
             bool isAsync,
             bool isDefer
         );
-        string GenerateInlineScripts(IUrlHelper urlHelper, ResourceLocation location);
+        string GenerateInlineScripts(ResourceLocation location);
         string GenerateScripts(
             IUrlHelper urlHelper,
             ResourceLocation location,

--- a/projects/Hood.Core/Services/PageBuilder/PageBuilder.cs
+++ b/projects/Hood.Core/Services/PageBuilder/PageBuilder.cs
@@ -203,7 +203,7 @@ namespace Hood.Services
             logWriter.Dispose();
         }
 
-        public virtual string GenerateInlineScripts(IUrlHelper urlHelper, ResourceLocation location)
+        public virtual string GenerateInlineScripts(ResourceLocation location)
         {
             if (!_inlineScripts.ContainsKey(location) || _inlineScripts[location] == null)
                 return "";

--- a/projects/Hood.Core/Services/PageBuilder/PageBuilder.cs
+++ b/projects/Hood.Core/Services/PageBuilder/PageBuilder.cs
@@ -21,7 +21,6 @@ namespace Hood.Services
         private readonly IHoodCache _cache;
         private readonly BundleFileProcessor _bundleFileProcessor;
 
-        private readonly Dictionary<ResourceLocation, List<FileReferenceMetadata>> _css;
         private readonly Dictionary<ResourceLocation, List<FileReferenceMetadata>> _scripts;
         private readonly Dictionary<ResourceLocation, List<string>> _inlineScripts;
 
@@ -31,7 +30,6 @@ namespace Hood.Services
             _cache = cache;
             _scripts = new Dictionary<ResourceLocation, List<FileReferenceMetadata>>();
             _inlineScripts = new Dictionary<ResourceLocation, List<string>>();
-            _css = new Dictionary<ResourceLocation, List<FileReferenceMetadata>>();
             _bundleFileProcessor = new BundleFileProcessor();
         }
 

--- a/projects/Hood.Core/Services/PageBuilder/PageBuilder.cs
+++ b/projects/Hood.Core/Services/PageBuilder/PageBuilder.cs
@@ -227,7 +227,7 @@ namespace Hood.Services
             if (parts == null || parts.Length == 0)
                 throw new ArgumentException("parts");
 
-            var hash = "";
+            string hash;
             using (SHA256 sha = SHA256.Create())
             {
                 var hashInput = "";

--- a/projects/Hood.Core/Services/PropertyImporter/BlmFileImporter.cs
+++ b/projects/Hood.Core/Services/PropertyImporter/BlmFileImporter.cs
@@ -657,7 +657,7 @@ namespace Hood.Services
                         Lock.ReleaseWriterLock();
 
                         string imageFile = TempFolder + data[key];
-                        IMediaObject mediaResult = null;
+                        IMediaObject mediaResult;
                         FileInfo fi = new FileInfo(imageFile);
                         using (FileStream s = File.OpenRead(imageFile))
                         {
@@ -751,7 +751,7 @@ namespace Hood.Services
                         if (!HasFileError())
                         {
                             string imageFile = TempFolder + data[key];
-                            MediaObject mediaResult = null;
+                            MediaObject mediaResult;
                             FileInfo fi = new FileInfo(imageFile);
                             using (FileStream s = File.OpenRead(imageFile))
                             {
@@ -840,7 +840,7 @@ namespace Hood.Services
                                 StatusMessage =
                                     $"Thumbnailing and processing image ({data[key]})...";
                                 Lock.ReleaseWriterLock();
-                                MediaObject mediaResult = null;
+                                MediaObject mediaResult;
                                 FileInfo fi = new FileInfo(imageFile);
                                 using (FileStream s = File.OpenRead(imageFile))
                                 {
@@ -903,7 +903,7 @@ namespace Hood.Services
                             Lock.ReleaseWriterLock();
 
                             string imageFile = TempFolder + data[key];
-                            MediaObject mediaResult = null;
+                            MediaObject mediaResult;
                             FileInfo fi = new FileInfo(imageFile);
                             string fileName = data[key].ToLower().Replace(".jpg", ".pdf");
                             using (FileStream s = File.OpenRead(imageFile))
@@ -1092,7 +1092,6 @@ namespace Hood.Services
                 .Trim(Environment.NewLine.ToCharArray())
                 .Trim()
                 .Split(new[] { '^' }, StringSplitOptions.RemoveEmptyEntries);
-            List<string> defs = definitions.ToList();
 
             string stringData = fileContents
                 .ExtractTextBetween("#DATA#", "#END#")
@@ -1614,9 +1613,8 @@ namespace Hood.Services
 
         private bool HasFileError()
         {
-            bool fileError = false;
             Lock.AcquireWriterLock(Timeout.Infinite);
-            fileError = FileError;
+            bool fileError = FileError;
             Lock.ReleaseWriterLock();
             return fileError;
         }

--- a/projects/Hood.Core/Services/PropertyImporter/BlmFileImporter.cs
+++ b/projects/Hood.Core/Services/PropertyImporter/BlmFileImporter.cs
@@ -27,12 +27,10 @@ namespace Hood.Services
         private readonly IWebHostEnvironment _env;
         private readonly IConfiguration _config;
         private readonly IDirectoryManager _directoryManager;
-        private readonly IHttpContextAccessor _context;
 
         public BlmFileImporter(
             IFTPService ftp,
             IWebHostEnvironment env,
-            IHttpContextAccessor context,
             IConfiguration config,
             IAddressService address,
             ILogService logService,
@@ -64,7 +62,6 @@ namespace Hood.Services
 
             LocalFolder =
                 env.ContentRootPath + "\\" + _propertySettings.FTPImporterSettings.LocalFolder;
-            _context = context;
             _address = address;
             _logService = logService;
         }
@@ -136,7 +133,7 @@ namespace Hood.Services
                 propertyDbOptions.UseSqlServer(_config["ConnectionStrings:DefaultConnection"]);
                 _db = new PropertyContext(propertyDbOptions.Options);
 
-                _media = new MediaManager(_env, _config);
+                _media = new MediaManager(_config);
 
                 MediaDirectory propertyDirectory = _hoodDb.MediaDirectories.SingleOrDefault(md =>
                     md.Slug == MediaManager.PropertyDirectorySlug && md.Type == DirectoryType.System

--- a/projects/Hood.Core/Services/PropertyImporter/BlmFileImporter.cs
+++ b/projects/Hood.Core/Services/PropertyImporter/BlmFileImporter.cs
@@ -14,7 +14,6 @@ using Hood.Models;
 using ICSharpCode.SharpZipLib.Core;
 using ICSharpCode.SharpZipLib.Zip;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
@@ -24,7 +23,6 @@ namespace Hood.Services
     public class BlmFileImporter : IPropertyImporter
     {
         private readonly IFTPService _ftp;
-        private readonly IWebHostEnvironment _env;
         private readonly IConfiguration _config;
         private readonly IDirectoryManager _directoryManager;
 
@@ -38,7 +36,6 @@ namespace Hood.Services
         )
         {
             _ftp = ftp;
-            _env = env;
             _config = config;
             _directoryManager = directoryManager;
             Lock = new ReaderWriterLock();
@@ -97,7 +94,7 @@ namespace Hood.Services
         private readonly ILogService _logService;
         private string DirectoryPath { get; set; }
 
-        public async Task RunUpdate(HttpContext context, string userId, string userName)
+        public async Task RunUpdate(string userId, string userName)
         {
             try
             {
@@ -662,7 +659,6 @@ namespace Hood.Services
                                 s,
                                 fi.Name,
                                 MimeTypes.GetMimeType(fi.Extension),
-                                fi.Length,
                                 DirectoryPath
                             );
                         }
@@ -757,7 +753,6 @@ namespace Hood.Services
                                         s,
                                         fi.Name,
                                         MimeTypes.GetMimeType(fi.Extension),
-                                        fi.Length,
                                         DirectoryPath
                                     ) as MediaObject;
                             }
@@ -846,7 +841,6 @@ namespace Hood.Services
                                             s,
                                             fi.Name,
                                             MimeTypes.GetMimeType(fi.Extension),
-                                            fi.Length,
                                             DirectoryPath
                                         ) as MediaObject;
                                 }
@@ -901,7 +895,6 @@ namespace Hood.Services
 
                             string imageFile = TempFolder + data[key];
                             MediaObject mediaResult;
-                            FileInfo fi = new FileInfo(imageFile);
                             string fileName = data[key].ToLower().Replace(".jpg", ".pdf");
                             using (FileStream s = File.OpenRead(imageFile))
                             {
@@ -910,7 +903,6 @@ namespace Hood.Services
                                         s,
                                         fileName,
                                         MimeTypes.GetMimeType("pdf"),
-                                        fi.Length,
                                         DirectoryPath
                                     ) as MediaObject;
                             }

--- a/projects/Hood.Core/Services/PropertyImporter/BlmFileImporter.cs
+++ b/projects/Hood.Core/Services/PropertyImporter/BlmFileImporter.cs
@@ -1093,9 +1093,6 @@ namespace Hood.Services
                 .Trim()
                 .Split(new[] { '^' }, StringSplitOptions.RemoveEmptyEntries);
             List<string> defs = definitions.ToList();
-            int imageTasks = defs.Count(c => c.Contains("MEDIA_IMAGE") && !c.Contains("TEXT"));
-            int docTasks = defs.Count(c => c.Contains("MEDIA_FLOOR_PLAN") && !c.Contains("TEXT"));
-            int fpTasks = defs.Count(c => c.Contains("MEDIA_DOCUMENT") && !c.Contains("TEXT"));
 
             string stringData = fileContents
                 .ExtractTextBetween("#DATA#", "#END#")
@@ -1197,8 +1194,6 @@ namespace Hood.Services
             }
 
             property.Bedrooms = bedrooms;
-
-            string furnished = PropertyDetails.Furnished[int.Parse(data["LET_FURN_ID"])];
 
             string propertyType = PropertyDetails.PropertyTypes[int.Parse(data["PROP_SUB_ID"])];
             property.PropertyType = propertyType;

--- a/projects/Hood.Core/Services/PropertyImporter/BlmFileImporter.cs
+++ b/projects/Hood.Core/Services/PropertyImporter/BlmFileImporter.cs
@@ -1164,7 +1164,9 @@ namespace Hood.Services
         /// <summary>
         /// Takes the dictionary object and translates it into a full PropertyListing object, ready to insert to db.
         /// </summary>
-        /// <param name="data">Property</param>
+        /// <param name="property">The PropertyListing to populate.</param>
+        /// <param name="data">The BLM field dictionary for the property.</param>
+        /// <param name="validatingOnly">When true, parse/validate without side effects like media downloads.</param>
         /// <returns></returns>
         private async Task<PropertyListing> ProcessPropertyAsync(
             PropertyListing property,

--- a/projects/Hood.Core/Services/PropertyImporter/IPropertyImporter.cs
+++ b/projects/Hood.Core/Services/PropertyImporter/IPropertyImporter.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 
 namespace Hood.Services
 {
@@ -7,7 +6,7 @@ namespace Hood.Services
     {
         bool IsComplete();
         bool IsRunning();
-        Task RunUpdate(HttpContext context, string userId, string userName);
+        Task RunUpdate(string userId, string userName);
         void Kill();
         PropertyImporterReport Report();
     }

--- a/projects/Hood.Core/Services/PropertyRepository/IPropertyRepository.cs
+++ b/projects/Hood.Core/Services/PropertyRepository/IPropertyRepository.cs
@@ -13,8 +13,8 @@ namespace Hood.Services
         Task<List<MapMarker>> GetLocationsAsync(PropertyListModel filters);
         Task<PropertyListModel> GetFeaturedAsync();
         Task<PropertyListModel> GetRecentAsync();
-        Task<PropertyListing> GetPropertyByIdAsync(int id, bool nocache = false);
-        Task<PropertyListingView> GetPropertyViewByIdAsync(int id, bool nocache = false);
+        Task<PropertyListing> GetPropertyByIdAsync(int id);
+        Task<PropertyListingView> GetPropertyViewByIdAsync(int id);
         Task<PropertyListing> ReloadReferences(PropertyListing property);
         Task<PropertyListing> AddAsync(PropertyListing property);
         Task UpdateAsync(PropertyListing property);

--- a/projects/Hood.Core/Services/PropertyRepository/PropertyRepository.cs
+++ b/projects/Hood.Core/Services/PropertyRepository/PropertyRepository.cs
@@ -286,7 +286,7 @@ namespace Hood.Services
             }
         }
 
-        public async Task<PropertyListing> GetPropertyByIdAsync(int id, bool nocache = false)
+        public async Task<PropertyListing> GetPropertyByIdAsync(int id)
         {
             PropertyListing property = await _db
                 .Properties.Include(p => p.Media)
@@ -298,10 +298,7 @@ namespace Hood.Services
             return property;
         }
 
-        public async Task<PropertyListingView> GetPropertyViewByIdAsync(
-            int id,
-            bool nocache = false
-        )
+        public async Task<PropertyListingView> GetPropertyViewByIdAsync(int id)
         {
             PropertyListingView property = await _db
                 .PropertyViews.Include(p => p.Media)

--- a/projects/Hood.Core/Services/RazorViewRenderer/RazorViewRenderer.cs
+++ b/projects/Hood.Core/Services/RazorViewRenderer/RazorViewRenderer.cs
@@ -17,17 +17,11 @@ namespace Hood.Services
     {
         private readonly IRazorViewEngine _viewEngine;
         private readonly ITempDataProvider _tempDataProvider;
-        private readonly IServiceProvider _serviceProvider;
 
-        public RazorViewRenderer(
-            IRazorViewEngine viewEngine,
-            ITempDataProvider tempDataProvider,
-            IServiceProvider serviceProvider
-        )
+        public RazorViewRenderer(IRazorViewEngine viewEngine, ITempDataProvider tempDataProvider)
         {
             _viewEngine = viewEngine;
             _tempDataProvider = tempDataProvider;
-            _serviceProvider = serviceProvider;
         }
 
         public async Task<string> Render(string viewPath)

--- a/projects/Hood.Core/Services/SettingsRepository/SettingsRepository.cs
+++ b/projects/Hood.Core/Services/SettingsRepository/SettingsRepository.cs
@@ -16,11 +16,13 @@ namespace Hood.Services
     {
         private readonly HoodDbContext _db;
         private readonly IHoodCache _cache;
+        private readonly IEventsService _events;
 
-        public SettingsRepository(HoodDbContext db, IHoodCache cache)
+        public SettingsRepository(HoodDbContext db, IHoodCache cache, IEventsService events)
         {
             _db = db;
             _cache = cache;
+            _events = events;
         }
 
         #region Private Accessors
@@ -69,6 +71,8 @@ namespace Hood.Services
                 }
                 _db.SaveChanges();
                 _cache.Remove(key);
+                // Settings changed — let subscribers (content/type caches) rebuild (HOOD-82).
+                _events.TriggerOptionsChanged(this);
             }
             catch (DbUpdateException ex)
             {

--- a/projects/Hood.Core/Services/SettingsRepository/SettingsRepository.cs
+++ b/projects/Hood.Core/Services/SettingsRepository/SettingsRepository.cs
@@ -15,13 +15,11 @@ namespace Hood.Services
     public class SettingsRepository : ISettingsRepository
     {
         private readonly HoodDbContext _db;
-        private readonly IConfiguration _config;
         private readonly IHoodCache _cache;
 
-        public SettingsRepository(HoodDbContext db, IConfiguration config, IHoodCache cache)
+        public SettingsRepository(HoodDbContext db, IHoodCache cache)
         {
             _db = db;
-            _config = config;
             _cache = cache;
         }
 

--- a/projects/Hood.Core/Services/SmsSender/ISmsSender.cs
+++ b/projects/Hood.Core/Services/SmsSender/ISmsSender.cs
@@ -4,6 +4,7 @@ namespace Hood.Services
 {
     public interface ISmsSender
     {
+        // ReSharper disable twice UnusedParameter.Global — SMS contract; the bundled sender is a stub, real implementations need both.
         Task SendSmsAsync(string number, string message);
     }
 }

--- a/projects/Hood.Core/Services/TypeFinder/TypeFinder.cs
+++ b/projects/Hood.Core/Services/TypeFinder/TypeFinder.cs
@@ -9,8 +9,6 @@ namespace Hood.Core
 {
     public class TypeFinder : ITypeFinder
     {
-        public TypeFinder() { }
-
         #region Methods
 
         /// <summary>

--- a/projects/Hood.Core/Services/ViewLocationExpander/ViewLocationExpander.cs
+++ b/projects/Hood.Core/Services/ViewLocationExpander/ViewLocationExpander.cs
@@ -10,8 +10,6 @@ namespace Hood.Services
     {
         private IEnumerable<string> locs;
 
-        public ViewLocationExpander() { }
-
         public void PopulateValues(ViewLocationExpanderContext context)
         {
             string theme =

--- a/projects/Hood.Core/Startup/IApplicationBuilderExtensions.cs
+++ b/projects/Hood.Core/Startup/IApplicationBuilderExtensions.cs
@@ -87,7 +87,7 @@ namespace Hood.Startup
 
             app.UseHoodComponents(env, config);
 
-            app.UseHoodDefaultRoutes(config);
+            app.UseHoodDefaultRoutes();
 
             return app;
         }
@@ -121,10 +121,7 @@ namespace Hood.Startup
             return app;
         }
 
-        public static IApplicationBuilder UseHoodDefaultRoutes(
-            this IApplicationBuilder app,
-            IConfiguration config
-        )
+        public static IApplicationBuilder UseHoodDefaultRoutes(this IApplicationBuilder app)
         {
             app.UseEndpoints(endpoints =>
             {

--- a/projects/Hood.Core/Startup/IHostExtensions.cs
+++ b/projects/Hood.Core/Startup/IHostExtensions.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.Threading.Tasks;
 using Hood.Core;
 using Hood.Enums;

--- a/projects/Hood.Core/Startup/IHostExtensions.cs
+++ b/projects/Hood.Core/Startup/IHostExtensions.cs
@@ -15,7 +15,6 @@ namespace Hood.Startup
         {
             using (IServiceScope scope = host.Services.CreateScope())
             {
-                IServiceProvider services = scope.ServiceProvider;
                 // Get the database from the services provider
                 HoodDbContext db = scope.ServiceProvider.GetService<HoodDbContext>();
                 try

--- a/projects/Hood.Core/Startup/IServiceCollectionExtensions.cs
+++ b/projects/Hood.Core/Startup/IServiceCollectionExtensions.cs
@@ -276,7 +276,7 @@ namespace Hood.Startup
             //create, initialize and configure the engine
             IHoodServiceProvider engine = Engine.CreateHoodServiceProvider();
             engine.Initialize(services);
-            IServiceProvider serviceProvider = engine.ConfigureServices(services, configuration);
+            engine.ConfigureServices(services, configuration);
 
             return services;
         }

--- a/projects/Hood.Core/Startup/IServiceCollectionExtensions.cs
+++ b/projects/Hood.Core/Startup/IServiceCollectionExtensions.cs
@@ -700,7 +700,7 @@ namespace Hood.Startup
                     : null;
             });
 
-            int sessionTimeout = 60;
+            int sessionTimeout;
             services.AddSession(options =>
             {
                 options.Cookie.IsEssential = true;

--- a/projects/Hood.Core/Startup/IServiceCollectionExtensions.cs
+++ b/projects/Hood.Core/Startup/IServiceCollectionExtensions.cs
@@ -56,13 +56,12 @@ namespace Hood.Startup
 
         public static IServiceCollection ConfigureHoodApi(
             this IServiceCollection services,
-            IConfiguration config,
-            IWebHostEnvironment env
+            IConfiguration config
         )
         {
             try
             {
-                services.ConfigureHoodCore(config, env);
+                services.ConfigureHoodCore(config);
 
                 services.AddCors(options =>
                 {
@@ -119,8 +118,7 @@ namespace Hood.Startup
 
         public static IServiceCollection ConfigureHoodCore(
             this IServiceCollection services,
-            IConfiguration config,
-            IWebHostEnvironment env
+            IConfiguration config
         )
         {
             try
@@ -150,7 +148,7 @@ namespace Hood.Startup
             services.ConfigureProperty(config);
             services.ConfigureContent(config);
 
-            services.ConfigureCache(config);
+            services.ConfigureCache();
             services.ConfigureCacheProfiles();
 
             services.ConfigureDataProtection(config);
@@ -282,10 +280,7 @@ namespace Hood.Startup
 
         #region Caching
 
-        public static IServiceCollection ConfigureCache(
-            this IServiceCollection services,
-            IConfiguration config
-        )
+        public static IServiceCollection ConfigureCache(this IServiceCollection services)
         {
             // Caching
             //if (config["ConnectionStrings:RedisCache"].IsSet())

--- a/projects/Hood.Core/Startup/IServiceCollectionExtensions.cs
+++ b/projects/Hood.Core/Startup/IServiceCollectionExtensions.cs
@@ -46,7 +46,7 @@ namespace Hood.Startup
             try
             {
                 // Register core stuff.
-                services.ConfigureHoodBasics(config, env);
+                services.ConfigureHoodBasics(config);
                 services.ConfigureHoodSite(config, env);
                 services.ConfigureHoodEngine(config);
             }
@@ -126,7 +126,7 @@ namespace Hood.Startup
             try
             {
                 // Register core stuff.
-                services.ConfigureHoodBasics(config, env);
+                services.ConfigureHoodBasics(config);
                 services.ConfigureHoodEngine(config);
             }
             catch (StartupException) { }
@@ -135,8 +135,7 @@ namespace Hood.Startup
 
         private static IServiceCollection ConfigureHoodBasics(
             this IServiceCollection services,
-            IConfiguration config,
-            IWebHostEnvironment env
+            IConfiguration config
         )
         {
             services.Configure<HoodConfiguration>(config.GetSection("Hood"));
@@ -437,7 +436,7 @@ namespace Hood.Startup
             services.Configure<CookiePolicyOptions>(options =>
             {
                 // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => consentRequired;
+                options.CheckConsentNeeded = _ => consentRequired;
                 options.MinimumSameSitePolicy = SameSiteMode.None;
                 options.ConsentCookie.Name = $"{cookieName}_consent";
                 options.ConsentCookie.Domain = config["Identity:Cookies:Domain"].IsSet()

--- a/projects/Hood.Core/TagHelpers/FixedImageTagHelper.cs
+++ b/projects/Hood.Core/TagHelpers/FixedImageTagHelper.cs
@@ -23,8 +23,6 @@ namespace Hood.TagHelpers
         [HtmlAttributeName("color")]
         public string Colour { get; set; }
 
-        public FixedImageTagHelper() { }
-
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
             output.TagName = "div";

--- a/projects/Hood.Core/TagHelpers/MediaAttachTagHelper.cs
+++ b/projects/Hood.Core/TagHelpers/MediaAttachTagHelper.cs
@@ -105,11 +105,6 @@ namespace Hood.TagHelpers
             if (For.ModelExplorer.Metadata.DisplayName.IsSet())
                 fieldDisplayName = For.ModelExplorer.Metadata.DisplayName;
 
-            string fieldDescription;
-            if (For.ModelExplorer.Metadata.Description.IsSet())
-                fieldDescription =
-                    $"<small class='form-text text-info'>{For.ModelExplorer.Metadata.Description}</small>";
-
             string fieldId = Guid.NewGuid().ToString();
 
             string fieldValue = For.Model != null ? For.Model.ToString() : "";

--- a/projects/Hood.Core/TagHelpers/ModelFieldHelper.cs
+++ b/projects/Hood.Core/TagHelpers/ModelFieldHelper.cs
@@ -55,8 +55,8 @@ namespace Hood.TagHelpers
             }
             output.Attributes.SetAttribute("class", classValue);
 
-            string LabelClass = "";
-            string FieldDivClass = "";
+            string LabelClass;
+            string FieldDivClass;
             if (FormLayout == "horizontal")
             {
                 LabelClass = "col-sm-4 control-label";

--- a/projects/Hood.Core/TagHelpers/RecaptchaTagHelper.cs
+++ b/projects/Hood.Core/TagHelpers/RecaptchaTagHelper.cs
@@ -2,10 +2,8 @@
 using Hood.Core;
 using Hood.Enums;
 using Hood.Extensions;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Microsoft.Extensions.Hosting;
 
 namespace Hood.TagHelpers
 {

--- a/projects/Hood.Core/TagHelpers/RecaptchaTagHelper.cs
+++ b/projects/Hood.Core/TagHelpers/RecaptchaTagHelper.cs
@@ -21,6 +21,7 @@ namespace Hood.TagHelpers
         /// </summary>
         /// <param name="htmlHelper">HTML helper</param>
         /// <param name="httpContextAccessor">HTTP context accessor</param>
+        /// <param name="env">Host environment</param>
         public RecapcthaTagHelper(
             IHtmlHelper htmlHelper,
             IHttpContextAccessor httpContextAccessor,

--- a/projects/Hood.Core/TagHelpers/RecaptchaTagHelper.cs
+++ b/projects/Hood.Core/TagHelpers/RecaptchaTagHelper.cs
@@ -13,24 +13,14 @@ namespace Hood.TagHelpers
     public class RecapcthaTagHelper : TagHelper
     {
         private readonly IHtmlHelper _htmlHelper;
-        private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly IHostEnvironment _env;
 
         /// <summary>
         /// Ctor
         /// </summary>
         /// <param name="htmlHelper">HTML helper</param>
-        /// <param name="httpContextAccessor">HTTP context accessor</param>
-        /// <param name="env">Host environment</param>
-        public RecapcthaTagHelper(
-            IHtmlHelper htmlHelper,
-            IHttpContextAccessor httpContextAccessor,
-            IHostEnvironment env
-        )
+        public RecapcthaTagHelper(IHtmlHelper htmlHelper)
         {
             _htmlHelper = htmlHelper;
-            _httpContextAccessor = httpContextAccessor;
-            _env = env;
         }
 
         public override int Order { get; } = int.MaxValue;

--- a/projects/Hood.Core/TagHelpers/ScriptTagHelper.cs
+++ b/projects/Hood.Core/TagHelpers/ScriptTagHelper.cs
@@ -13,7 +13,6 @@ namespace Hood.TagHelpers
     public class ScriptTagHelper : TagHelper
     {
         private readonly IHtmlHelper _htmlHelper;
-        private readonly IHttpContextAccessor _httpContextAccessor;
 
         /// <summary>
         /// Indicates where the script should be rendered
@@ -39,10 +38,9 @@ namespace Hood.TagHelpers
         /// </summary>
         /// <param name="htmlHelper">HTML helper</param>
         /// <param name="httpContextAccessor">HTTP context accessor</param>
-        public ScriptTagHelper(IHtmlHelper htmlHelper, IHttpContextAccessor httpContextAccessor)
+        public ScriptTagHelper(IHtmlHelper htmlHelper)
         {
             _htmlHelper = htmlHelper;
-            _httpContextAccessor = httpContextAccessor;
         }
 
         /// <summary>

--- a/projects/Hood.Core/TagHelpers/ScriptTagHelper.cs
+++ b/projects/Hood.Core/TagHelpers/ScriptTagHelper.cs
@@ -2,7 +2,6 @@ using System;
 using Hood.Enums;
 using Hood.Extensions;
 using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -37,7 +36,6 @@ namespace Hood.TagHelpers
         /// Ctor
         /// </summary>
         /// <param name="htmlHelper">HTML helper</param>
-        /// <param name="httpContextAccessor">HTTP context accessor</param>
         public ScriptTagHelper(IHtmlHelper htmlHelper)
         {
             _htmlHelper = htmlHelper;

--- a/projects/Hood.Core/ViewModels/Account/SpamPreventionForm.cs
+++ b/projects/Hood.Core/ViewModels/Account/SpamPreventionForm.cs
@@ -11,8 +11,6 @@ namespace Hood.ViewModels
 {
     public class SpamPreventionModel : SaveableModel, IValidatableObject
     {
-        public SpamPreventionModel() { }
-
         public const string HoneypotFieldName = "full_enquiry";
 
         [FromForm(Name = HoneypotFieldName)]

--- a/projects/Hood.Core/ViewModels/Account/SpamPreventionForm.cs
+++ b/projects/Hood.Core/ViewModels/Account/SpamPreventionForm.cs
@@ -45,7 +45,6 @@ namespace Hood.ViewModels
             var hasher = new PasswordHasher(this.Salt);
             hasher = hasher.HashPasswordWithSalt(this.Timestamp);
             var hash = hasher.HashedPassword;
-            var salt = hasher.Base64Salt;
 
             if (hash != this.Hash)
             {

--- a/projects/Hood.Core/ViewModels/Content/ContentModel.cs
+++ b/projects/Hood.Core/ViewModels/Content/ContentModel.cs
@@ -8,8 +8,6 @@ namespace Hood.ViewModels
 {
     public class ContentModel : PagedList<ContentView>
     {
-        public ContentModel() { }
-
         public override int PageSize
         {
             get

--- a/projects/Hood.Core/ViewModels/Content/ContentTypeListModel.cs
+++ b/projects/Hood.Core/ViewModels/Content/ContentTypeListModel.cs
@@ -14,8 +14,6 @@ namespace Hood.ViewModels
         )]
         public bool HideDisabled { get; set; }
 
-        public ContentTypeListModel() { }
-
         public override string GetPageUrl(int pageIndex)
         {
             var query = base.GetPageUrl(pageIndex);

--- a/projects/Hood.Core/ViewModels/Logs/LogListModel.cs
+++ b/projects/Hood.Core/ViewModels/Logs/LogListModel.cs
@@ -7,9 +7,6 @@ namespace Hood.ViewModels
 {
     public class LogListModel : PagedList<Log>
     {
-        public LogListModel()
-        {
-        }
 
         [FromQuery(Name = "userId")]
         public string UserId { get; set; }

--- a/projects/Hood.Core/ViewModels/Users/RoleListModel.cs
+++ b/projects/Hood.Core/ViewModels/Users/RoleListModel.cs
@@ -2,8 +2,5 @@
 
 namespace Hood.ViewModels
 {
-    public class RoleListModel<TRole> : PagedList<TRole>
-    {
-        public RoleListModel() { }
-    }
+    public class RoleListModel<TRole> : PagedList<TRole> { }
 }

--- a/projects/Hood.Core/ViewModels/Users/UserListModel.cs
+++ b/projects/Hood.Core/ViewModels/Users/UserListModel.cs
@@ -6,15 +6,10 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Hood.ViewModels
 {
-    public class UserListModel : UserListModel<IUserProfile>
-    {
-        public UserListModel() { }
-    }
+    public class UserListModel : UserListModel<IUserProfile> { }
 
     public class UserListModel<TUserProfile> : PagedList<TUserProfile>
     {
-        public UserListModel() { }
-
         [FromQuery(Name = "role")]
         public string Role { get; set; }
 

--- a/projects/Hood.Development/Areas/Admin/UI/Auth0Users/Edit.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Auth0Users/Edit.cshtml
@@ -1,7 +1,6 @@
 @model UserProfileView<Auth0Role>
 @{
     ViewBag.Title = "Edit User: " + Model.UserName;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 @section buttons {
     <a href="javascript:document.getElementById('edit-user-form').submit()" class="btn btn-success"><i class="fa fa-save"></i> Save Profile</a>

--- a/projects/Hood.Development/Areas/Admin/UI/Auth0Users/EditRole.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Auth0Users/EditRole.cshtml
@@ -1,7 +1,6 @@
 @model Auth0Role
 @{
     ViewBag.Title = "Edit Role: " + Model.Name;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 @section buttons {
 <a href="javascript:document.getElementById('edit-user-form').submit()" class="btn btn-success"><i class="fa fa-save"></i> Save Profile</a>

--- a/projects/Hood.Development/Areas/Admin/UI/Auth0Users/Roles.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Auth0Users/Roles.cshtml
@@ -1,5 +1,4 @@
 @model RoleListModel<Auth0Role>
-@inject IAuth0AccountRepository _account;
 @{
     ViewBag.Title = "Website Roles";
 }

--- a/projects/Hood.Development/Areas/Admin/UI/Content/_Editor_Sidebar.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Content/_Editor_Sidebar.cshtml
@@ -1,5 +1,4 @@
 @model Content
-@inject ContentCategoryCache _categories
 
 <div class="card mb-3">
     <div class="card-header position-relative" id="content-access-panel-heading">

--- a/projects/Hood.Development/Areas/Admin/UI/Content/_List_Categories.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Content/_List_Categories.cshtml
@@ -2,7 +2,6 @@
 @inject ContentCategoryCache _categories
 @{
     Layout = null;
-    var categories = _categories.TopLevel(Model.ContentType.Type);
 }
 <div class="card mb-3">
     <div class="card-header position-relative" id="content-category-panel-heading">

--- a/projects/Hood.Development/Areas/Admin/UI/Content/_List_Categories.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Content/_List_Categories.cshtml
@@ -16,7 +16,7 @@
         <div class='list-group list-group-flush'>
             @if (_categories.Count(Model.ContentType.Type) > 0)
             {
-                @_categories.AdminContentCategoryTree(_categories.TopLevel(Model.ContentType.Type), Model.ContentType.Type, Model.Categories)
+                @_categories.AdminContentCategoryTree(_categories.TopLevel(Model.ContentType.Type), Model.Categories)
             }
             else
             {

--- a/projects/Hood.Development/Areas/Admin/UI/Content/_List_Content.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Content/_List_Content.cshtml
@@ -1,5 +1,4 @@
 @model ContentModel
-@inject ContentCategoryCache _categories
 @{
     Layout = null;
 }

--- a/projects/Hood.Development/Areas/Admin/UI/Import/BlmImporter.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Import/BlmImporter.cshtml
@@ -1,6 +1,5 @@
 @{
     ViewBag.Title = "Import Properties via BLM";
-    PropertySettings _propertySettings = Engine.Settings.Property;
 }
 @section buttons {
     <a class="btn btn-primary" asp-action="Manage" asp-controller="Property" asp-area="Admin"><i class="fa fa-list-ol mr-2"></i>Back to List</a>

--- a/projects/Hood.Development/Areas/Admin/UI/Layouts/_Layout.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Layouts/_Layout.cshtml
@@ -11,13 +11,13 @@
     <link type="image/png" href="@Engine.Resource("/images/hood-square.png")" rel="icon" />
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeCss)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeCss)
 
     <partial name="_Styles" />
     @RenderSection("styles", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.AfterCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterCss)
+    @Html.RenderInlineScripts(ResourceLocation.AfterCss)
 
 </head>
 <body class="@(!production ? "dev-mode" : "")">
@@ -64,12 +64,12 @@
     </div>
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeScripts, production)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeScripts)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeScripts)
 
     <partial name="_Scripts" />
     @RenderSection("scripts", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.AfterScripts, production)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterScripts)
+    @Html.RenderInlineScripts(ResourceLocation.AfterScripts)
 </body>
 </html>

--- a/projects/Hood.Development/Areas/Admin/UI/Media/Action.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Media/Action.cshtml
@@ -1,5 +1,4 @@
 @model MediaListModel
-@inject IDirectoryManager _directoryManager
 @{
     Layout = null;
 }

--- a/projects/Hood.Development/Areas/Admin/UI/Media/Index.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Media/Index.cshtml
@@ -1,5 +1,4 @@
 @model MediaListModel
-@inject IDirectoryManager _directoryManager
 @{
     ViewBag.Title = "Website Media";
 }

--- a/projects/Hood.Development/Areas/Admin/UI/Media/_Blade_Directory.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Media/_Blade_Directory.cshtml
@@ -1,5 +1,4 @@
 @model MediaDirectory
-@inject IDirectoryManager _directoryManager
 @{
     Layout = null;
 }

--- a/projects/Hood.Development/Areas/Admin/UI/Property/_Editor_Features.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Property/_Editor_Features.cshtml
@@ -1,5 +1,4 @@
 @model PropertyListing
-@inject IContentRepository _data
 @{
 }
 <div id="features" class="tab-pane">

--- a/projects/Hood.Development/Areas/Admin/UI/Property/_Editor_Features.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Property/_Editor_Features.cshtml
@@ -1,7 +1,6 @@
 @model PropertyListing
 @inject IContentRepository _data
 @{
-    PropertySettings _propertySettings = Engine.Settings.Property;
 }
 <div id="features" class="tab-pane">
     <h5 class="mt-2 mb-0">Features</h5>

--- a/projects/Hood.Development/Areas/Admin/UI/Property/_Editor_Info.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Property/_Editor_Info.cshtml
@@ -1,5 +1,4 @@
 @model PropertyListing
-@inject IContentRepository _data
 @{
     var _integrationSettings = Engine.Settings.Integrations;
 }

--- a/projects/Hood.Development/Areas/Admin/UI/Property/_Editor_Prices.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Property/_Editor_Prices.cshtml
@@ -1,5 +1,4 @@
 @model PropertyListing
-@inject IContentRepository _data
 
 @{
     PropertySettings _propertySettings = Engine.Settings.Property;

--- a/projects/Hood.Development/Areas/Admin/UI/Property/_Editor_Tabs.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Property/_Editor_Tabs.cshtml
@@ -1,7 +1,6 @@
 @model PropertyListing
 @inject IContentRepository _data
 @{
-    PropertySettings _propertySettings = Engine.Settings.Property;
 }
 <partial name="_Editor_Hidden" />
 <div class="card">

--- a/projects/Hood.Development/Areas/Admin/UI/Property/_Editor_Tabs.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Property/_Editor_Tabs.cshtml
@@ -1,5 +1,4 @@
 @model PropertyListing
-@inject IContentRepository _data
 @{
 }
 <partial name="_Editor_Hidden" />

--- a/projects/Hood.Development/Areas/Admin/UI/Settings/Advanced.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Settings/Advanced.cshtml
@@ -1,6 +1,4 @@
-@inject IThemesService _theme
 @inject IConfiguration _config
-@inject IContentRepository _data
 @inject IHoodCache _cache
 @{
     ViewData["Title"] = "Administrator Tools";

--- a/projects/Hood.Development/Areas/Admin/UI/Shared/_Scripts.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Shared/_Scripts.cshtml
@@ -1,5 +1,3 @@
-@inject IThemesService _themes
-@inject IConfiguration _config
 @{
 }
 <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>

--- a/projects/Hood.Development/Areas/Admin/UI/Shared/_Scripts.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Shared/_Scripts.cshtml
@@ -1,7 +1,6 @@
 @inject IThemesService _themes
 @inject IConfiguration _config
 @{
-    IntegrationSettings _plugins = Engine.Settings.Integrations;
 }
 <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>

--- a/projects/Hood.Development/Areas/Admin/UI/Shared/_Styles.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Shared/_Styles.cshtml
@@ -1,4 +1,3 @@
-@inject IThemesService _themes
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@simonwep/pickr/dist/themes/monolith.min.css" />
 

--- a/projects/Hood.Development/Areas/Admin/UI/Users/Edit.cshtml
+++ b/projects/Hood.Development/Areas/Admin/UI/Users/Edit.cshtml
@@ -1,7 +1,6 @@
 @model UserProfileView<IdentityRole>
 @{
     ViewBag.Title = "Edit User: " + Model.UserName;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 @section buttons {
     <a href="javascript:document.getElementById('edit-user-form').submit()" class="btn btn-success"><i class="fa fa-save"></i> Save Profile</a>

--- a/projects/Hood.Development/Controllers/AccountController.cs
+++ b/projects/Hood.Development/Controllers/AccountController.cs
@@ -2,8 +2,5 @@
 {
     // Standard ASP.NET Identity is the default backend. Use the Auth0 base
     // (Hood.BaseControllers.Auth0AccountController) only when Auth0 is configured.
-    public class AccountController : Hood.BaseControllers.AccountController
-    {
-        public AccountController() { }
-    }
+    public class AccountController : Hood.BaseControllers.AccountController { }
 }

--- a/projects/Hood.Development/Controllers/ErrorController.cs
+++ b/projects/Hood.Development/Controllers/ErrorController.cs
@@ -1,7 +1,4 @@
 ﻿namespace Hood.Web.Controllers
 {
-    public class ErrorController : Hood.BaseControllers.ErrorController
-    {
-        public ErrorController() { }
-    }
+    public class ErrorController : Hood.BaseControllers.ErrorController { }
 }

--- a/projects/Hood.Development/Controllers/HomeController.cs
+++ b/projects/Hood.Development/Controllers/HomeController.cs
@@ -1,7 +1,4 @@
 ﻿namespace Hood.Web.Controllers
 {
-    public class HomeController : Hood.BaseControllers.HomeController
-    {
-        public HomeController() { }
-    }
+    public class HomeController : Hood.BaseControllers.HomeController { }
 }

--- a/projects/Hood.Development/Controllers/HoodController.cs
+++ b/projects/Hood.Development/Controllers/HoodController.cs
@@ -1,7 +1,4 @@
 ﻿namespace Hood.Web.Controllers
 {
-    public class HoodController : Hood.BaseControllers.HoodController
-    {
-        public HoodController() { }
-    }
+    public class HoodController : Hood.BaseControllers.HoodController { }
 }

--- a/projects/Hood.Development/Controllers/PropertyController.cs
+++ b/projects/Hood.Development/Controllers/PropertyController.cs
@@ -1,7 +1,4 @@
 ﻿namespace Hood.Web.Controllers
 {
-    public class PropertyController : Hood.BaseControllers.PropertyController
-    {
-        public PropertyController() { }
-    }
+    public class PropertyController : Hood.BaseControllers.PropertyController { }
 }

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Blocks/CallToAction.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Blocks/CallToAction.cshtml
@@ -1,7 +1,6 @@
 @{
     Layout = null;
-    bool fullwidth = true;
-    bool.TryParse(Context.Request.Query["fullwidth"], out fullwidth);
+    bool.TryParse(Context.Request.Query["fullwidth"], out bool fullwidth);
     var container = "container";
     if (fullwidth)
     {

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Blocks/Columns.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Blocks/Columns.cshtml
@@ -1,20 +1,15 @@
 ﻿@{
     Layout = null;
-    bool fullwidth = true;
-    bool.TryParse(Context.Request.Query["fullwidth"], out fullwidth);
+    bool.TryParse(Context.Request.Query["fullwidth"], out bool fullwidth);
     var container = "container";
     if (fullwidth)
     {
         container = "";
     }
-    bool icons = true;
-    bool.TryParse(Context.Request.Query["icons"], out icons);
-    bool buttons = true;
-    bool.TryParse(Context.Request.Query["buttons"], out buttons);
-    int rows = 1;
-    int.TryParse(Context.Request.Query["rows"], out rows);
-    int cols = 3;
-    int.TryParse(Context.Request.Query["cols"], out cols);
+    bool.TryParse(Context.Request.Query["icons"], out bool icons);
+    bool.TryParse(Context.Request.Query["buttons"], out bool buttons);
+    int.TryParse(Context.Request.Query["rows"], out int rows);
+    int.TryParse(Context.Request.Query["cols"], out int cols);
     var align = Context.Request.Query["align"];
     var cssClass = Context.Request.Query["class"];
 }

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Blocks/ImageSection.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Blocks/ImageSection.cshtml
@@ -1,7 +1,6 @@
 @{
     Layout = null;
-    bool fullwidth = true;
-    bool.TryParse(Context.Request.Query["fullwidth"], out fullwidth);
+    bool.TryParse(Context.Request.Query["fullwidth"], out bool fullwidth);
     var container = "container";
     if (fullwidth)
     {

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Home/Feed.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Home/Feed.cshtml
@@ -17,12 +17,6 @@
     }
 
     SeoSettings _seoSettings = Engine.Settings.Seo;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 
 }
 @section metas {

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Home/Feed.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Home/Feed.cshtml
@@ -2,7 +2,7 @@
 @{
     string title = Model.ContentType.MetaTitle.IsSet() ? Model.ContentType.MetaTitle : Model.ContentType.Title;
     ViewData["Title"] = title;
-    var Feed = "_Feed";
+    string Feed;
 
     @switch (Model.ContentType.BaseName)
     {

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Home/Index.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Home/Index.cshtml
@@ -1,6 +1,5 @@
 @{
     var _basicSettings = Engine.Settings.Basic;
-    var _integrations = Engine.Settings.Integrations;
     var _seoSettings = Engine.Settings.Seo;
     string description = _basicSettings.Address.ToFormat(AddressFormat.SingleLine);
     string title = _basicSettings.FullTitle;

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Home/Partials/_Author.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Home/Partials/_Author.cshtml
@@ -1,6 +1,5 @@
 @model ContentModel
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 @if (Model.Content.ShowAuthor)
 {

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Home/Partials/_Recent.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Home/Partials/_Recent.cshtml
@@ -1,5 +1,4 @@
 @model PagedList<ContentView>
-@inject IContentRepository _content
 @if (Model != null && Model.List.Count > 0)
 {
     <div class="sidebar-widget m-b-lg">

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Home/Partials/_View_Portfolio.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Home/Partials/_View_Portfolio.cshtml
@@ -1,6 +1,5 @@
 @model ContentModel
 @{
-    IntegrationSettings _integrationSettings = Engine.Settings.Integrations;
 }
 <div class="row">
     <div class="col-sm-8 col-lg-9">

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Home/Show.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Home/Show.cshtml
@@ -53,11 +53,6 @@
         }
     }
 
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 }
 @section metas {
     <meta name="description" content="@description" />

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Home/Show.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Home/Show.cshtml
@@ -29,7 +29,7 @@
         ViewData["ExitDesignerUrl"] = Model.Content.Url;
     }
 
-    var View = "_View";
+    string View;
 
     @switch (Model.ContentType.BaseName)
     {

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Layouts/_Layout.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Layouts/_Layout.cshtml
@@ -23,13 +23,13 @@
     @RenderSection("metas", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeCss)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeCss)
 
     <partial name="_Styles" />
     @RenderSection("styles", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.AfterCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterCss)
+    @Html.RenderInlineScripts(ResourceLocation.AfterCss)
 
 </head>
 <body class="@ViewData["BodyClass"]">
@@ -52,12 +52,12 @@
     @RenderSection("includes", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeScripts)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeScripts)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeScripts)
 
     <partial name="_Scripts" />
 
     @Html.RenderScripts(Url, ResourceLocation.AfterScripts)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterScripts)
+    @Html.RenderInlineScripts(ResourceLocation.AfterScripts)
 
     @RenderSection("scripts", required: false)
 

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Layouts/_Layout.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Layouts/_Layout.cshtml
@@ -1,5 +1,4 @@
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     SeoSettings _seoSettings = Engine.Settings.Seo;
 
     var pageTitle = ViewData["PageTitle"] as string;

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Property/Index.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Property/Index.cshtml
@@ -6,12 +6,6 @@
 
     SeoSettings _seoSettings = Engine.Settings.Seo;
     BasicSettings _basicSettings = Engine.Settings.Basic;
-    PropertySettings _propertySettings = Engine.Settings.Property;
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 
 }
 @section metas {

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Property/Modal.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Property/Modal.cshtml
@@ -1,7 +1,5 @@
 @model ShowPropertyModel
 @{
-    SeoSettings _seoSettings = Engine.Settings.Seo;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     Layout = null;
 }
 <div class="modal-dialog" role="document">

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Property/Show.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Property/Show.cshtml
@@ -6,27 +6,16 @@
     PropertySettings _propertySettings = Engine.Settings.Property;
 
     var cmTitle = Model.Property.GetMeta("SEO.Meta.Title");
-    var cmDesc = Model.Property.GetMeta("SEO.Meta.Description");
     string metaTitle = Model.Property.Title + " - " + _basicSettings.FullTitle;
-    string metaDesc = Model.Property.ShortDescription;
     if (!cmTitle.GetStringValue().IsNullOrEmpty())
     {
         metaTitle = cmTitle.GetStringValue();
-    }
-    if (!cmDesc.GetStringValue().IsNullOrEmpty())
-    {
-        metaDesc = cmDesc.GetStringValue();
     }
     ViewBag.Title = metaTitle;
     ViewData["EditUrl"] = Url.Action("Edit", "Property", new { area = "Admin", id = Model.Property.Id });
 
     Layout = "_Layout";
 
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 }
 @section metas {
     <meta name="description" content="@Model.Property.ShortDescription" />

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_ContactForm.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_ContactForm.cshtml
@@ -1,7 +1,6 @@
 @model ContactFormModel
 @{
     ContactSettings _contactSettings = Engine.Settings.Contact;
-    IntegrationSettings _integrationSettings = Engine.Settings.Integrations;
 }
 <form method="post"
       role="form"

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_DeferredStyles.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_DeferredStyles.cshtml
@@ -1,4 +1,3 @@
-@inject IThemesService _themes
 
 @* ADD PRELOAD STYLES HERE *@
 

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_Header_Menu_Account.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_Header_Menu_Account.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @model HeaderModel
 @{
 }

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_Header_Menu_Account.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_Header_Menu_Account.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @model HeaderModel
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 <div class="row">
     <div class="col-sm-4">

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_Header_Menu_Main.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_Header_Menu_Main.cshtml
@@ -1,6 +1,5 @@
 @inject IContentRepository _content
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     var path = Context.Request.Path.ToString().ToLower();
 }
 <nav class="main">

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_Header_Menu_Mobile.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_Header_Menu_Mobile.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @model HeaderModel
 @{
 }

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_Header_Menu_Mobile.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_Header_Menu_Mobile.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @model HeaderModel
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 <nav class="mobile">
     <div class="logo">

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_Metas.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_Metas.cshtml
@@ -1,5 +1,4 @@
 @{ 
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     SeoSettings _seoSettings = Engine.Settings.Seo;
     var OgTitle = _seoSettings.OgTitle.IsSet() ? _seoSettings.OgTitle : ViewData["Title"];
     var OgImageUrl = _seoSettings.OgImageUrl.IsSet() ? _seoSettings.OgImageUrl : "http://placehold.it/1200x630";

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_Styles.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Shared/_Styles.cshtml
@@ -1,3 +1,2 @@
-@inject IThemesService _themes
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/hoodcms@4.1.6/css/styles.bs3.min.css">

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Templates/_Full.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Templates/_Full.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
     Layout = "_Blank";
 }

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Templates/_Full.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Templates/_Full.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @{
     Layout = "_Blank";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Templates/_Full_with_Hero.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Templates/_Full_with_Hero.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
     Layout = "_Layout";
 }

--- a/projects/Hood.Development/Themes/bootstrap3/Views/Templates/_Full_with_Hero.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap3/Views/Templates/_Full_with_Hero.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @{
     Layout = "_Layout";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Home/Feed.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Home/Feed.cshtml
@@ -17,12 +17,6 @@
     }
 
     SeoSettings _seoSettings = Engine.Settings.Seo;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 
 }
 @section metas {

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Home/Feed.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Home/Feed.cshtml
@@ -2,7 +2,7 @@
 @{
     string title = Model.ContentType.MetaTitle.IsSet() ? Model.ContentType.MetaTitle : Model.ContentType.Title;
     ViewData["Title"] = title;
-    var Feed = "_Feed";
+    string Feed;
 
     @switch (Model.ContentType.BaseName)
     {

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Home/Index.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Home/Index.cshtml
@@ -1,6 +1,5 @@
 @{
     var _basicSettings = Engine.Settings.Basic;
-    var _integrations = Engine.Settings.Integrations;
     var _seoSettings = Engine.Settings.Seo;
     string description = _basicSettings.Address.ToFormat(AddressFormat.SingleLine);
     string title = "Home - " + _basicSettings.FullTitle;

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Home/Partials/_Author.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Home/Partials/_Author.cshtml
@@ -1,6 +1,5 @@
 @model ContentModel
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 @if (Model.Content.ShowAuthor)
 {

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Home/Partials/_Recent.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Home/Partials/_Recent.cshtml
@@ -1,5 +1,4 @@
 @model PagedList<ContentView>
-@inject IContentRepository _content
 @if (Model != null && Model.List.Count > 0)
 {
             @foreach (ContentView content in Model.List)

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Home/Show.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Home/Show.cshtml
@@ -24,7 +24,7 @@
 
     ViewData["EditUrl"] = Url.Action("Edit", "Content", new { area = "Admin", id = Model.Content.Id });
 
-    var View = "_View";
+    string View;
 
     @switch (Model.ContentType.BaseName)
     {

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Hood/Maintenance.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Hood/Maintenance.cshtml
@@ -1,6 +1,5 @@
 @{
     var _basicSettings = Engine.Settings.Basic;
-    var _integrations = Engine.Settings.Integrations;
     var _seoSettings = Engine.Settings.Seo;
     string description = _basicSettings.Address.ToFormat(AddressFormat.SingleLine);
     string title = "Undergoing Maintenance - " +  _basicSettings.FullTitle;

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Layouts/_Layout.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Layouts/_Layout.cshtml
@@ -18,13 +18,13 @@
     @RenderSection("metas", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeCss)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeCss)
 
     <partial name="_Styles" />
     @RenderSection("styles", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.AfterCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterCss)
+    @Html.RenderInlineScripts(ResourceLocation.AfterCss)
 
 </head>
 <body class="@(!production ? "dev-mode" : "")">
@@ -51,12 +51,12 @@
 
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeScripts, production)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeScripts)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeScripts)
 
     <partial name="_Scripts" />
 
     @Html.RenderScripts(Url, ResourceLocation.AfterScripts, production)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterScripts)
+    @Html.RenderInlineScripts(ResourceLocation.AfterScripts)
 
     @RenderSection("scripts", required: false)
 

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Property/Index.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Property/Index.cshtml
@@ -6,12 +6,6 @@
 
     SeoSettings _seoSettings = Engine.Settings.Seo;
     BasicSettings _basicSettings = Engine.Settings.Basic;
-    PropertySettings _propertySettings = Engine.Settings.Property;
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 
 }
 @section metas {

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Property/Modal.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Property/Modal.cshtml
@@ -1,7 +1,5 @@
 @model ShowPropertyModel
 @{
-    SeoSettings _seoSettings = Engine.Settings.Seo;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     Layout = null;
 }
 <div class="modal-dialog" role="document">

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Property/Show.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Property/Show.cshtml
@@ -6,16 +6,10 @@
     PropertySettings _propertySettings = Engine.Settings.Property;
 
     var cmTitle = Model.Property.GetMeta("SEO.Meta.Title");
-    var cmDesc = Model.Property.GetMeta("SEO.Meta.Description");
     string metaTitle = Model.Property.Title + " - " + _basicSettings.FullTitle;
-    string metaDesc = Model.Property.ShortDescription;
     if (!cmTitle.GetStringValue().IsNullOrEmpty())
     {
         metaTitle = cmTitle.GetStringValue();
-    }
-    if (!cmDesc.GetStringValue().IsNullOrEmpty())
-    {
-        metaDesc = cmDesc.GetStringValue();
     }
     ViewBag.Title = metaTitle;
     ViewBag.PageTitle = Model.Property.Title;

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_ContactForm.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_ContactForm.cshtml
@@ -1,7 +1,6 @@
 @model ContactFormModel
 @{
     ContactSettings _contactSettings = Engine.Settings.Contact;
-    IntegrationSettings _integrationSettings = Engine.Settings.Integrations;
 }
 <form method="post"
       role="form"

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_DeferredStyles.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_DeferredStyles.cshtml
@@ -1,4 +1,3 @@
-@inject IThemesService _themes
 
 @* ADD PRELOAD STYLES HERE *@
 

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_Header_Menu_Account.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_Header_Menu_Account.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @model HeaderModel
 @{
 }

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_Header_Menu_Account.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_Header_Menu_Account.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @model HeaderModel
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 <nav class="modal fade modal-left" id="account-menu" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog modal-blade" role="document">

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_Header_Menu_Main.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_Header_Menu_Main.cshtml
@@ -1,7 +1,5 @@
 @inject IContentRepository _content
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
-    var path = Context.Request.Path.ToString().ToLower();
 }
 <ul class="navbar-nav mr-auto">
     <li class="nav-item active">

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_Header_Menu_Main.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_Header_Menu_Main.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
 }
 <ul class="navbar-nav mr-auto">

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_Header_Menu_Mobile.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_Header_Menu_Mobile.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @model HeaderModel
 @{
     BasicSettings _basicSettings = Engine.Settings.Basic;

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_Metas.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_Metas.cshtml
@@ -1,5 +1,4 @@
 @{ 
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     SeoSettings _seoSettings = Engine.Settings.Seo;
     var OgTitle = _seoSettings.OgTitle.IsSet() ? _seoSettings.OgTitle : ViewData["Title"];
     var OgImageUrl = _seoSettings.OgImageUrl.IsSet() ? _seoSettings.OgImageUrl : "http://placehold.it/1200x630";

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_Styles.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Shared/_Styles.cshtml
@@ -1,3 +1,2 @@
-@inject IThemesService _themes
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/hoodcms@4.1.6/css/styles.bs4.min.css">

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Templates/_Blank.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Templates/_Blank.cshtml
@@ -1,6 +1,5 @@
 @{
     Layout = "_Layout_Basic";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Templates/_Full.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Templates/_Full.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
     Layout = "_Blank";
 }

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Templates/_Full.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Templates/_Full.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @{
     Layout = "_Blank";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Templates/_Full_with_Hero.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Templates/_Full_with_Hero.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
     Layout = "_Layout";
 }

--- a/projects/Hood.Development/Themes/bootstrap4/Views/Templates/_Full_with_Hero.cshtml
+++ b/projects/Hood.Development/Themes/bootstrap4/Views/Templates/_Full_with_Hero.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @{
     Layout = "_Layout";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood.Development/Views/Account/Login.cshtml
+++ b/projects/Hood.Development/Views/Account/Login.cshtml
@@ -1,5 +1,4 @@
 @model LoginViewModel
-@inject IContentRepository _content
 @{
     ViewData["Title"] = "Sign in";
 

--- a/projects/Hood.Development/Views/Account/Register.cshtml
+++ b/projects/Hood.Development/Views/Account/Register.cshtml
@@ -1,5 +1,4 @@
 @model PasswordRegisterViewModel
-@inject IContentRepository _content
 @{
     ViewData["Title"] = "Create an Account";
 

--- a/projects/Hood.Development/Views/Account/RegistrationClosed.cshtml
+++ b/projects/Hood.Development/Views/Account/RegistrationClosed.cshtml
@@ -1,5 +1,4 @@
 @model MagicLoginViewModel
-@inject IContentRepository _content
 @{
     ViewData["Title"] = "Registration Closed";
 

--- a/projects/Hood.Development/Views/Home/Feed.cshtml
+++ b/projects/Hood.Development/Views/Home/Feed.cshtml
@@ -17,12 +17,6 @@
     }
 
     SeoSettings _seoSettings = Engine.Settings.Seo;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 
 }
 @section metas {

--- a/projects/Hood.Development/Views/Home/Feed.cshtml
+++ b/projects/Hood.Development/Views/Home/Feed.cshtml
@@ -2,7 +2,7 @@
 @{
     string title = Model.ContentType.MetaTitle.IsSet() ? Model.ContentType.MetaTitle : Model.ContentType.Title;
     ViewData["Title"] = title;
-    var Feed = "_Feed";
+    string Feed;
 
     @switch (Model.ContentType.BaseName)
     {

--- a/projects/Hood.Development/Views/Home/Index.cshtml
+++ b/projects/Hood.Development/Views/Home/Index.cshtml
@@ -1,7 +1,6 @@
 @{
     Layout = "_Layout";
     var _basicSettings = Engine.Settings.Basic;
-    var _integrations = Engine.Settings.Integrations;
     var _seoSettings = Engine.Settings.Seo;
     string description = _basicSettings.Address.ToFormat(AddressFormat.SingleLine);
     string title = "Home - " + _basicSettings.FullTitle;

--- a/projects/Hood.Development/Views/Home/Partials/_Author.cshtml
+++ b/projects/Hood.Development/Views/Home/Partials/_Author.cshtml
@@ -1,6 +1,5 @@
 @model ContentModel
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 @if (Model.Content.ShowAuthor)
 {

--- a/projects/Hood.Development/Views/Home/Partials/_Recent.cshtml
+++ b/projects/Hood.Development/Views/Home/Partials/_Recent.cshtml
@@ -1,5 +1,4 @@
 @model PagedList<ContentView>
-@inject IContentRepository _content
 @if (Model != null && Model.List.Count > 0)
 {
     @foreach (ContentView content in Model.List)

--- a/projects/Hood.Development/Views/Home/Show.cshtml
+++ b/projects/Hood.Development/Views/Home/Show.cshtml
@@ -24,7 +24,7 @@
 
     ViewData["EditUrl"] = Url.Action("Edit", "Content", new { area = "Admin", id = Model.Content.Id });
 
-    var View = "_View";
+    string View;
 
     @switch (Model.ContentType.BaseName)
     {

--- a/projects/Hood.Development/Views/Hood/Maintenance.cshtml
+++ b/projects/Hood.Development/Views/Hood/Maintenance.cshtml
@@ -1,6 +1,5 @@
 @{
     var _basicSettings = Engine.Settings.Basic;
-    var _integrations = Engine.Settings.Integrations;
     var _seoSettings = Engine.Settings.Seo;
     string description = _basicSettings.Address.ToFormat(AddressFormat.SingleLine);
     string title = "Undergoing Maintenance - " +  _basicSettings.FullTitle;

--- a/projects/Hood.Development/Views/Layouts/_Layout.cshtml
+++ b/projects/Hood.Development/Views/Layouts/_Layout.cshtml
@@ -18,13 +18,13 @@
     @RenderSection("metas", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeCss)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeCss)
 
     <partial name="_Styles" />
     @RenderSection("styles", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.AfterCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterCss)
+    @Html.RenderInlineScripts(ResourceLocation.AfterCss)
 
 </head>
 <body class="@(!production ? "dev-mode" : "")">
@@ -60,13 +60,13 @@
 
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeScripts, production)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeScripts)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeScripts)
 
     <partial name="_Scripts_Vendors" />    
     <partial name="_Scripts" />
 
     @Html.RenderScripts(Url, ResourceLocation.AfterScripts, production)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterScripts)
+    @Html.RenderInlineScripts(ResourceLocation.AfterScripts)
 
     @RenderSection("scripts", required: false)
 

--- a/projects/Hood.Development/Views/Layouts/_Layout_Login.cshtml
+++ b/projects/Hood.Development/Views/Layouts/_Layout_Login.cshtml
@@ -43,13 +43,13 @@
     </div>
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeScripts)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeScripts)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeScripts)
 
     <partial name="_Scripts_Login" />
     @RenderSection("scripts", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.AfterScripts)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterScripts)
+    @Html.RenderInlineScripts(ResourceLocation.AfterScripts)
 
     @Html.Raw(Engine.Settings.Seo.GoogleAnalytics)
 

--- a/projects/Hood.Development/Views/Property/Index.cshtml
+++ b/projects/Hood.Development/Views/Property/Index.cshtml
@@ -5,14 +5,8 @@
 
     SeoSettings _seoSettings = Engine.Settings.Seo;
     BasicSettings _basicSettings = Engine.Settings.Basic;
-    PropertySettings _propertySettings = Engine.Settings.Property;
     IntegrationSettings _plugins = Engine.Settings.Integrations;
 
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 
     bool maps = _plugins.GoogleMapsApiKey.IsSet() && (_plugins.EnableGoogleMaps || _plugins.EnableGoogleGeocoding);
 }

--- a/projects/Hood.Development/Views/Property/Modal.cshtml
+++ b/projects/Hood.Development/Views/Property/Modal.cshtml
@@ -1,7 +1,5 @@
 @model ShowPropertyModel
 @{
-    SeoSettings _seoSettings = Engine.Settings.Seo;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     Layout = null;
 }
 <div class="modal-dialog" role="document">

--- a/projects/Hood.Development/Views/Property/Show.cshtml
+++ b/projects/Hood.Development/Views/Property/Show.cshtml
@@ -6,16 +6,10 @@
     PropertySettings _propertySettings = Engine.Settings.Property;
 
     var cmTitle = Model.Property.GetMeta("SEO.Meta.Title");
-    var cmDesc = Model.Property.GetMeta("SEO.Meta.Description");
     string metaTitle = Model.Property.Title + " - " + _basicSettings.FullTitle;
-    string metaDesc = Model.Property.ShortDescription;
     if (!cmTitle.GetStringValue().IsNullOrEmpty())
     {
         metaTitle = cmTitle.GetStringValue();
-    }
-    if (!cmDesc.GetStringValue().IsNullOrEmpty())
-    {
-        metaDesc = cmDesc.GetStringValue();
     }
     ViewBag.Title = metaTitle;
     ViewBag.PageTitle = Model.Property.Title;

--- a/projects/Hood.Development/Views/Shared/_ContactForm.cshtml
+++ b/projects/Hood.Development/Views/Shared/_ContactForm.cshtml
@@ -1,7 +1,6 @@
 @model ContactFormModel
 @{
     ContactSettings _contactSettings = Engine.Settings.Contact;
-    IntegrationSettings _integrationSettings = Engine.Settings.Integrations;
 }
 <form method="post"
       role="form"

--- a/projects/Hood.Development/Views/Shared/_DeferredStyles.cshtml
+++ b/projects/Hood.Development/Views/Shared/_DeferredStyles.cshtml
@@ -1,4 +1,3 @@
-@inject IThemesService _themes
 
 @* ADD PRELOAD STYLES HERE *@
 

--- a/projects/Hood.Development/Views/Shared/_Header_Menu_Account.cshtml
+++ b/projects/Hood.Development/Views/Shared/_Header_Menu_Account.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
 }
 <nav class="modal fade modal-left" id="account-menu" tabindex="-1" role="dialog" aria-hidden="true">

--- a/projects/Hood.Development/Views/Shared/_Header_Menu_Account.cshtml
+++ b/projects/Hood.Development/Views/Shared/_Header_Menu_Account.cshtml
@@ -1,6 +1,5 @@
 @inject IContentRepository _content
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 <nav class="modal fade modal-left" id="account-menu" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog modal-blade" role="document">

--- a/projects/Hood.Development/Views/Shared/_Header_Menu_Main.cshtml
+++ b/projects/Hood.Development/Views/Shared/_Header_Menu_Main.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
 }
 <ul class="navbar-nav me-auto">

--- a/projects/Hood.Development/Views/Shared/_Header_Menu_Main.cshtml
+++ b/projects/Hood.Development/Views/Shared/_Header_Menu_Main.cshtml
@@ -1,7 +1,5 @@
 @inject IContentRepository _content
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
-    var path = Context.Request.Path.ToString().ToLower();
 }
 <ul class="navbar-nav me-auto">
     <li class="nav-item active">

--- a/projects/Hood.Development/Views/Shared/_Header_Menu_Mobile.cshtml
+++ b/projects/Hood.Development/Views/Shared/_Header_Menu_Mobile.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
     BasicSettings _basicSettings = Engine.Settings.Basic;
 }

--- a/projects/Hood.Development/Views/Shared/_Metas.cshtml
+++ b/projects/Hood.Development/Views/Shared/_Metas.cshtml
@@ -1,5 +1,4 @@
 @{ 
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     SeoSettings _seoSettings = Engine.Settings.Seo;
     var OgTitle = _seoSettings.OgTitle.IsSet() ? _seoSettings.OgTitle : ViewData["Title"];
     var OgImageUrl = _seoSettings.OgImageUrl.IsSet() ? _seoSettings.OgImageUrl : "http://placehold.it/1200x630";

--- a/projects/Hood.Development/Views/Shared/_Styles.cshtml
+++ b/projects/Hood.Development/Views/Shared/_Styles.cshtml
@@ -1,4 +1,3 @@
-@inject IThemesService _themes
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 <environment exclude="Production">
     <link rel="stylesheet" href="@Engine.Resource("/src/css/app.css")" asp-append-version="true">

--- a/projects/Hood.Development/Views/Shared/_Styles_Login.cshtml
+++ b/projects/Hood.Development/Views/Shared/_Styles_Login.cshtml
@@ -1,4 +1,3 @@
-@inject IThemesService _themes
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@simonwep/pickr/dist/themes/monolith.min.css" />
 <environment exclude="Production">

--- a/projects/Hood.Development/Views/Templates/_Blank.cshtml
+++ b/projects/Hood.Development/Views/Templates/_Blank.cshtml
@@ -1,6 +1,5 @@
 @{
     Layout = "_Layout";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
 @RenderSection("styles", required: false)

--- a/projects/Hood.Development/Views/Templates/_Contact.cshtml
+++ b/projects/Hood.Development/Views/Templates/_Contact.cshtml
@@ -2,7 +2,6 @@
     BasicSettings _basicSettings  = Engine.Settings.Basic;
     IntegrationSettings _plugins = Engine.Settings.Integrations;
     Layout = "_Layout";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood.Development/Views/Templates/_Full.cshtml
+++ b/projects/Hood.Development/Views/Templates/_Full.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
     Layout = "_Blank";
 }

--- a/projects/Hood.Development/Views/Templates/_Full.cshtml
+++ b/projects/Hood.Development/Views/Templates/_Full.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @{
     Layout = "_Blank";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood.Development/Views/Templates/_Full_with_Hero.cshtml
+++ b/projects/Hood.Development/Views/Templates/_Full_with_Hero.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
     Layout = "_Layout";
 }

--- a/projects/Hood.Development/Views/Templates/_Full_with_Hero.cshtml
+++ b/projects/Hood.Development/Views/Templates/_Full_with_Hero.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @{
     Layout = "_Layout";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Auth0Users/Edit.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Auth0Users/Edit.cshtml
@@ -1,7 +1,6 @@
 @model UserProfileView<Auth0Role>
 @{
     ViewBag.Title = "Edit User: " + Model.UserName;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 @section buttons {
     <a href="javascript:document.getElementById('edit-user-form').submit()" class="btn btn-success"><i class="fa fa-save"></i> Save Profile</a>

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Auth0Users/EditRole.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Auth0Users/EditRole.cshtml
@@ -1,7 +1,6 @@
 @model Auth0Role
 @{
     ViewBag.Title = "Edit Role: " + Model.Name;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 @section buttons {
 <a href="javascript:document.getElementById('edit-user-form').submit()" class="btn btn-success"><i class="fa fa-save"></i> Save Profile</a>

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Auth0Users/Roles.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Auth0Users/Roles.cshtml
@@ -1,5 +1,4 @@
 @model RoleListModel<Auth0Role>
-@inject IAuth0AccountRepository _account;
 @{
     ViewBag.Title = "Website Roles";
 }

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Content/_Editor_Sidebar.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Content/_Editor_Sidebar.cshtml
@@ -1,5 +1,4 @@
 @model Content
-@inject ContentCategoryCache _categories
 
 <div class="card mb-3">
     <div class="card-header position-relative" id="content-access-panel-heading">

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Content/_List_Categories.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Content/_List_Categories.cshtml
@@ -2,7 +2,6 @@
 @inject ContentCategoryCache _categories
 @{
     Layout = null;
-    var categories = _categories.TopLevel(Model.ContentType.Type);
 }
 <div class="card mb-3">
     <div class="card-header position-relative" id="content-category-panel-heading">

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Content/_List_Categories.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Content/_List_Categories.cshtml
@@ -16,7 +16,7 @@
         <div class='list-group list-group-flush'>
             @if (_categories.Count(Model.ContentType.Type) > 0)
             {
-                @_categories.AdminContentCategoryTree(_categories.TopLevel(Model.ContentType.Type), Model.ContentType.Type, Model.Categories)
+                @_categories.AdminContentCategoryTree(_categories.TopLevel(Model.ContentType.Type), Model.Categories)
             }
             else
             {

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Content/_List_Content.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Content/_List_Content.cshtml
@@ -1,5 +1,4 @@
 @model ContentModel
-@inject ContentCategoryCache _categories
 @{
     Layout = null;
 }

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Import/BlmImporter.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Import/BlmImporter.cshtml
@@ -1,6 +1,5 @@
 @{
     ViewBag.Title = "Import Properties via BLM";
-    PropertySettings _propertySettings = Engine.Settings.Property;
 }
 @section buttons {
     <a class="btn btn-primary" asp-action="Manage" asp-controller="Property" asp-area="Admin"><i class="fa fa-list-ol mr-2"></i>Back to List</a>

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Layouts/_Layout.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Layouts/_Layout.cshtml
@@ -11,13 +11,13 @@
     <link type="image/png" href="@Engine.Resource("/images/hood-square.png")" rel="icon" />
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeCss)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeCss)
 
     <partial name="_Styles" />
     @RenderSection("styles", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.AfterCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterCss)
+    @Html.RenderInlineScripts(ResourceLocation.AfterCss)
 
 </head>
 <body class="@(!production ? "dev-mode" : "")">
@@ -64,12 +64,12 @@
     </div>
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeScripts, production)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeScripts)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeScripts)
 
     <partial name="_Scripts" />
     @RenderSection("scripts", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.AfterScripts, production)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterScripts)
+    @Html.RenderInlineScripts(ResourceLocation.AfterScripts)
 </body>
 </html>

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Media/Action.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Media/Action.cshtml
@@ -1,5 +1,4 @@
 @model MediaListModel
-@inject IDirectoryManager _directoryManager
 @{
     Layout = null;
 }

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Media/Index.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Media/Index.cshtml
@@ -1,5 +1,4 @@
 @model MediaListModel
-@inject IDirectoryManager _directoryManager
 @{
     ViewBag.Title = "Website Media";
 }

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Media/_Blade_Directory.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Media/_Blade_Directory.cshtml
@@ -1,5 +1,4 @@
 @model MediaDirectory
-@inject IDirectoryManager _directoryManager
 @{
     Layout = null;
 }

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Features.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Features.cshtml
@@ -1,5 +1,4 @@
 @model PropertyListing
-@inject IContentRepository _data
 @{
 }
 <div id="features" class="tab-pane">

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Features.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Features.cshtml
@@ -1,7 +1,6 @@
 @model PropertyListing
 @inject IContentRepository _data
 @{
-    PropertySettings _propertySettings = Engine.Settings.Property;
 }
 <div id="features" class="tab-pane">
     <h5 class="mt-2 mb-0">Features</h5>

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Info.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Info.cshtml
@@ -1,5 +1,4 @@
 @model PropertyListing
-@inject IContentRepository _data
 @{
     var _integrationSettings = Engine.Settings.Integrations;
 }

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Prices.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Prices.cshtml
@@ -1,5 +1,4 @@
 @model PropertyListing
-@inject IContentRepository _data
 
 @{
     PropertySettings _propertySettings = Engine.Settings.Property;

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Tabs.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Tabs.cshtml
@@ -1,7 +1,6 @@
 @model PropertyListing
 @inject IContentRepository _data
 @{
-    PropertySettings _propertySettings = Engine.Settings.Property;
 }
 <partial name="_Editor_Hidden" />
 <div class="card">

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Tabs.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Tabs.cshtml
@@ -1,5 +1,4 @@
 @model PropertyListing
-@inject IContentRepository _data
 @{
 }
 <partial name="_Editor_Hidden" />

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Settings/Advanced.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Settings/Advanced.cshtml
@@ -1,6 +1,4 @@
-@inject IThemesService _theme
 @inject IConfiguration _config
-@inject IContentRepository _data
 @inject IHoodCache _cache
 @{
     ViewData["Title"] = "Administrator Tools";

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Shared/_Scripts.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Shared/_Scripts.cshtml
@@ -1,5 +1,3 @@
-@inject IThemesService _themes
-@inject IConfiguration _config
 @{
 }
 <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Shared/_Scripts.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Shared/_Scripts.cshtml
@@ -1,7 +1,6 @@
 @inject IThemesService _themes
 @inject IConfiguration _config
 @{
-    IntegrationSettings _plugins = Engine.Settings.Integrations;
 }
 <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Shared/_Styles.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Shared/_Styles.cshtml
@@ -1,4 +1,3 @@
-@inject IThemesService _themes
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@simonwep/pickr/dist/themes/monolith.min.css" />
 

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Users/Edit.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Users/Edit.cshtml
@@ -1,7 +1,6 @@
 @model UserProfileView<IdentityRole>
 @{
     ViewBag.Title = "Edit User: " + Model.UserName;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 @section buttons {
     <a href="javascript:document.getElementById('edit-user-form').submit()" class="btn btn-success"><i class="fa fa-save"></i> Save Profile</a>

--- a/projects/Hood.UI.Bootstrap3/UI/Blocks/CallToAction.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Blocks/CallToAction.cshtml
@@ -1,7 +1,6 @@
 @{
     Layout = null;
-    bool fullwidth = true;
-    bool.TryParse(Context.Request.Query["fullwidth"], out fullwidth);
+    bool.TryParse(Context.Request.Query["fullwidth"], out bool fullwidth);
     var container = "container";
     if (fullwidth)
     {

--- a/projects/Hood.UI.Bootstrap3/UI/Blocks/Columns.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Blocks/Columns.cshtml
@@ -1,20 +1,15 @@
 ﻿@{
     Layout = null;
-    bool fullwidth = true;
-    bool.TryParse(Context.Request.Query["fullwidth"], out fullwidth);
+    bool.TryParse(Context.Request.Query["fullwidth"], out bool fullwidth);
     var container = "container";
     if (fullwidth)
     {
         container = "";
     }
-    bool icons = true;
-    bool.TryParse(Context.Request.Query["icons"], out icons);
-    bool buttons = true;
-    bool.TryParse(Context.Request.Query["buttons"], out buttons);
-    int rows = 1;
-    int.TryParse(Context.Request.Query["rows"], out rows);
-    int cols = 3;
-    int.TryParse(Context.Request.Query["cols"], out cols);
+    bool.TryParse(Context.Request.Query["icons"], out bool icons);
+    bool.TryParse(Context.Request.Query["buttons"], out bool buttons);
+    int.TryParse(Context.Request.Query["rows"], out int rows);
+    int.TryParse(Context.Request.Query["cols"], out int cols);
     var align = Context.Request.Query["align"];
     var cssClass = Context.Request.Query["class"];
 }

--- a/projects/Hood.UI.Bootstrap3/UI/Blocks/ImageSection.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Blocks/ImageSection.cshtml
@@ -1,7 +1,6 @@
 @{
     Layout = null;
-    bool fullwidth = true;
-    bool.TryParse(Context.Request.Query["fullwidth"], out fullwidth);
+    bool.TryParse(Context.Request.Query["fullwidth"], out bool fullwidth);
     var container = "container";
     if (fullwidth)
     {

--- a/projects/Hood.UI.Bootstrap3/UI/Home/Feed.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Home/Feed.cshtml
@@ -17,12 +17,6 @@
     }
 
     SeoSettings _seoSettings = Engine.Settings.Seo;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 
 }
 @section metas {

--- a/projects/Hood.UI.Bootstrap3/UI/Home/Feed.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Home/Feed.cshtml
@@ -2,7 +2,7 @@
 @{
     string title = Model.ContentType.MetaTitle.IsSet() ? Model.ContentType.MetaTitle : Model.ContentType.Title;
     ViewData["Title"] = title;
-    var Feed = "_Feed";
+    string Feed;
 
     @switch (Model.ContentType.BaseName)
     {

--- a/projects/Hood.UI.Bootstrap3/UI/Home/Index.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Home/Index.cshtml
@@ -1,6 +1,5 @@
 @{
     var _basicSettings = Engine.Settings.Basic;
-    var _integrations = Engine.Settings.Integrations;
     var _seoSettings = Engine.Settings.Seo;
     string description = _basicSettings.Address.ToFormat(AddressFormat.SingleLine);
     string title = _basicSettings.FullTitle;

--- a/projects/Hood.UI.Bootstrap3/UI/Home/Partials/_Author.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Home/Partials/_Author.cshtml
@@ -1,6 +1,5 @@
 @model ContentModel
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 @if (Model.Content.ShowAuthor)
 {

--- a/projects/Hood.UI.Bootstrap3/UI/Home/Partials/_Recent.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Home/Partials/_Recent.cshtml
@@ -1,5 +1,4 @@
 @model PagedList<ContentView>
-@inject IContentRepository _content
 @if (Model != null && Model.List.Count > 0)
 {
     <div class="sidebar-widget m-b-lg">

--- a/projects/Hood.UI.Bootstrap3/UI/Home/Partials/_View_Portfolio.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Home/Partials/_View_Portfolio.cshtml
@@ -1,6 +1,5 @@
 @model ContentModel
 @{
-    IntegrationSettings _integrationSettings = Engine.Settings.Integrations;
 }
 <div class="row">
     <div class="col-sm-8 col-lg-9">

--- a/projects/Hood.UI.Bootstrap3/UI/Home/Show.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Home/Show.cshtml
@@ -53,11 +53,6 @@
         }
     }
 
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 }
 @section metas {
     <meta name="description" content="@description" />

--- a/projects/Hood.UI.Bootstrap3/UI/Home/Show.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Home/Show.cshtml
@@ -29,7 +29,7 @@
         ViewData["ExitDesignerUrl"] = Model.Content.Url;
     }
 
-    var View = "_View";
+    string View;
 
     @switch (Model.ContentType.BaseName)
     {

--- a/projects/Hood.UI.Bootstrap3/UI/Layouts/_Layout.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Layouts/_Layout.cshtml
@@ -23,13 +23,13 @@
     @RenderSection("metas", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeCss)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeCss)
 
     <partial name="_Styles" />
     @RenderSection("styles", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.AfterCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterCss)
+    @Html.RenderInlineScripts(ResourceLocation.AfterCss)
 
 </head>
 <body class="@ViewData["BodyClass"]">
@@ -52,12 +52,12 @@
     @RenderSection("includes", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeScripts)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeScripts)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeScripts)
 
     <partial name="_Scripts" />
 
     @Html.RenderScripts(Url, ResourceLocation.AfterScripts)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterScripts)
+    @Html.RenderInlineScripts(ResourceLocation.AfterScripts)
 
     @RenderSection("scripts", required: false)
 

--- a/projects/Hood.UI.Bootstrap3/UI/Layouts/_Layout.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Layouts/_Layout.cshtml
@@ -1,5 +1,4 @@
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     SeoSettings _seoSettings = Engine.Settings.Seo;
 
     var pageTitle = ViewData["PageTitle"] as string;

--- a/projects/Hood.UI.Bootstrap3/UI/Property/Index.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Property/Index.cshtml
@@ -6,12 +6,6 @@
 
     SeoSettings _seoSettings = Engine.Settings.Seo;
     BasicSettings _basicSettings = Engine.Settings.Basic;
-    PropertySettings _propertySettings = Engine.Settings.Property;
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 
 }
 @section metas {

--- a/projects/Hood.UI.Bootstrap3/UI/Property/Modal.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Property/Modal.cshtml
@@ -1,7 +1,5 @@
 @model ShowPropertyModel
 @{
-    SeoSettings _seoSettings = Engine.Settings.Seo;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     Layout = null;
 }
 <div class="modal-dialog" role="document">

--- a/projects/Hood.UI.Bootstrap3/UI/Property/Show.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Property/Show.cshtml
@@ -6,27 +6,16 @@
     PropertySettings _propertySettings = Engine.Settings.Property;
 
     var cmTitle = Model.Property.GetMeta("SEO.Meta.Title");
-    var cmDesc = Model.Property.GetMeta("SEO.Meta.Description");
     string metaTitle = Model.Property.Title + " - " + _basicSettings.FullTitle;
-    string metaDesc = Model.Property.ShortDescription;
     if (!cmTitle.GetStringValue().IsNullOrEmpty())
     {
         metaTitle = cmTitle.GetStringValue();
-    }
-    if (!cmDesc.GetStringValue().IsNullOrEmpty())
-    {
-        metaDesc = cmDesc.GetStringValue();
     }
     ViewBag.Title = metaTitle;
     ViewData["EditUrl"] = Url.Action("Edit", "Property", new { area = "Admin", id = Model.Property.Id });
 
     Layout = "_Layout";
 
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 }
 @section metas {
     <meta name="description" content="@Model.Property.ShortDescription" />

--- a/projects/Hood.UI.Bootstrap3/UI/Shared/_ContactForm.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Shared/_ContactForm.cshtml
@@ -1,7 +1,6 @@
 @model ContactFormModel
 @{
     ContactSettings _contactSettings = Engine.Settings.Contact;
-    IntegrationSettings _integrationSettings = Engine.Settings.Integrations;
 }
 <form method="post"
       role="form"

--- a/projects/Hood.UI.Bootstrap3/UI/Shared/_DeferredStyles.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Shared/_DeferredStyles.cshtml
@@ -1,4 +1,3 @@
-@inject IThemesService _themes
 
 @* ADD PRELOAD STYLES HERE *@
 

--- a/projects/Hood.UI.Bootstrap3/UI/Shared/_Header_Menu_Account.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Shared/_Header_Menu_Account.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @model HeaderModel
 @{
 }

--- a/projects/Hood.UI.Bootstrap3/UI/Shared/_Header_Menu_Account.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Shared/_Header_Menu_Account.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @model HeaderModel
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 <div class="row">
     <div class="col-sm-4">

--- a/projects/Hood.UI.Bootstrap3/UI/Shared/_Header_Menu_Main.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Shared/_Header_Menu_Main.cshtml
@@ -1,6 +1,5 @@
 @inject IContentRepository _content
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     var path = Context.Request.Path.ToString().ToLower();
 }
 <nav class="main">

--- a/projects/Hood.UI.Bootstrap3/UI/Shared/_Header_Menu_Mobile.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Shared/_Header_Menu_Mobile.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @model HeaderModel
 @{
 }

--- a/projects/Hood.UI.Bootstrap3/UI/Shared/_Header_Menu_Mobile.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Shared/_Header_Menu_Mobile.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @model HeaderModel
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 <nav class="mobile">
     <div class="logo">

--- a/projects/Hood.UI.Bootstrap3/UI/Shared/_Metas.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Shared/_Metas.cshtml
@@ -1,5 +1,4 @@
 @{ 
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     SeoSettings _seoSettings = Engine.Settings.Seo;
     var OgTitle = _seoSettings.OgTitle.IsSet() ? _seoSettings.OgTitle : ViewData["Title"];
     var OgImageUrl = _seoSettings.OgImageUrl.IsSet() ? _seoSettings.OgImageUrl : "http://placehold.it/1200x630";

--- a/projects/Hood.UI.Bootstrap3/UI/Shared/_Styles.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Shared/_Styles.cshtml
@@ -1,3 +1,2 @@
-@inject IThemesService _themes
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/hoodcms@4.1.6/css/styles.bs3.min.css">

--- a/projects/Hood.UI.Bootstrap3/UI/Templates/_Full.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Templates/_Full.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
     Layout = "_Blank";
 }

--- a/projects/Hood.UI.Bootstrap3/UI/Templates/_Full.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Templates/_Full.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @{
     Layout = "_Blank";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood.UI.Bootstrap3/UI/Templates/_Full_with_Hero.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Templates/_Full_with_Hero.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
     Layout = "_Layout";
 }

--- a/projects/Hood.UI.Bootstrap3/UI/Templates/_Full_with_Hero.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Templates/_Full_with_Hero.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @{
     Layout = "_Layout";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood.UI.Bootstrap4/UI/Home/Feed.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Home/Feed.cshtml
@@ -17,12 +17,6 @@
     }
 
     SeoSettings _seoSettings = Engine.Settings.Seo;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 
 }
 @section metas {

--- a/projects/Hood.UI.Bootstrap4/UI/Home/Feed.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Home/Feed.cshtml
@@ -2,7 +2,7 @@
 @{
     string title = Model.ContentType.MetaTitle.IsSet() ? Model.ContentType.MetaTitle : Model.ContentType.Title;
     ViewData["Title"] = title;
-    var Feed = "_Feed";
+    string Feed;
 
     @switch (Model.ContentType.BaseName)
     {

--- a/projects/Hood.UI.Bootstrap4/UI/Home/Index.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Home/Index.cshtml
@@ -1,6 +1,5 @@
 @{
     var _basicSettings = Engine.Settings.Basic;
-    var _integrations = Engine.Settings.Integrations;
     var _seoSettings = Engine.Settings.Seo;
     string description = _basicSettings.Address.ToFormat(AddressFormat.SingleLine);
     string title = "Home - " + _basicSettings.FullTitle;

--- a/projects/Hood.UI.Bootstrap4/UI/Home/Partials/_Author.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Home/Partials/_Author.cshtml
@@ -1,6 +1,5 @@
 @model ContentModel
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 @if (Model.Content.ShowAuthor)
 {

--- a/projects/Hood.UI.Bootstrap4/UI/Home/Partials/_Recent.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Home/Partials/_Recent.cshtml
@@ -1,5 +1,4 @@
 @model PagedList<ContentView>
-@inject IContentRepository _content
 @if (Model != null && Model.List.Count > 0)
 {
             @foreach (ContentView content in Model.List)

--- a/projects/Hood.UI.Bootstrap4/UI/Home/Show.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Home/Show.cshtml
@@ -24,7 +24,7 @@
 
     ViewData["EditUrl"] = Url.Action("Edit", "Content", new { area = "Admin", id = Model.Content.Id });
 
-    var View = "_View";
+    string View;
 
     @switch (Model.ContentType.BaseName)
     {

--- a/projects/Hood.UI.Bootstrap4/UI/Hood/Maintenance.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Hood/Maintenance.cshtml
@@ -1,6 +1,5 @@
 @{
     var _basicSettings = Engine.Settings.Basic;
-    var _integrations = Engine.Settings.Integrations;
     var _seoSettings = Engine.Settings.Seo;
     string description = _basicSettings.Address.ToFormat(AddressFormat.SingleLine);
     string title = "Undergoing Maintenance - " +  _basicSettings.FullTitle;

--- a/projects/Hood.UI.Bootstrap4/UI/Layouts/_Layout.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Layouts/_Layout.cshtml
@@ -18,13 +18,13 @@
     @RenderSection("metas", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeCss)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeCss)
 
     <partial name="_Styles" />
     @RenderSection("styles", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.AfterCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterCss)
+    @Html.RenderInlineScripts(ResourceLocation.AfterCss)
 
 </head>
 <body class="@(!production ? "dev-mode" : "")">
@@ -51,12 +51,12 @@
 
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeScripts, production)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeScripts)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeScripts)
 
     <partial name="_Scripts" />
 
     @Html.RenderScripts(Url, ResourceLocation.AfterScripts, production)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterScripts)
+    @Html.RenderInlineScripts(ResourceLocation.AfterScripts)
 
     @RenderSection("scripts", required: false)
 

--- a/projects/Hood.UI.Bootstrap4/UI/Property/Index.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Property/Index.cshtml
@@ -6,12 +6,6 @@
 
     SeoSettings _seoSettings = Engine.Settings.Seo;
     BasicSettings _basicSettings = Engine.Settings.Basic;
-    PropertySettings _propertySettings = Engine.Settings.Property;
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 
 }
 @section metas {

--- a/projects/Hood.UI.Bootstrap4/UI/Property/Modal.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Property/Modal.cshtml
@@ -1,7 +1,5 @@
 @model ShowPropertyModel
 @{
-    SeoSettings _seoSettings = Engine.Settings.Seo;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     Layout = null;
 }
 <div class="modal-dialog" role="document">

--- a/projects/Hood.UI.Bootstrap4/UI/Property/Show.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Property/Show.cshtml
@@ -6,16 +6,10 @@
     PropertySettings _propertySettings = Engine.Settings.Property;
 
     var cmTitle = Model.Property.GetMeta("SEO.Meta.Title");
-    var cmDesc = Model.Property.GetMeta("SEO.Meta.Description");
     string metaTitle = Model.Property.Title + " - " + _basicSettings.FullTitle;
-    string metaDesc = Model.Property.ShortDescription;
     if (!cmTitle.GetStringValue().IsNullOrEmpty())
     {
         metaTitle = cmTitle.GetStringValue();
-    }
-    if (!cmDesc.GetStringValue().IsNullOrEmpty())
-    {
-        metaDesc = cmDesc.GetStringValue();
     }
     ViewBag.Title = metaTitle;
     ViewBag.PageTitle = Model.Property.Title;

--- a/projects/Hood.UI.Bootstrap4/UI/Shared/_ContactForm.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Shared/_ContactForm.cshtml
@@ -1,7 +1,6 @@
 @model ContactFormModel
 @{
     ContactSettings _contactSettings = Engine.Settings.Contact;
-    IntegrationSettings _integrationSettings = Engine.Settings.Integrations;
 }
 <form method="post"
       role="form"

--- a/projects/Hood.UI.Bootstrap4/UI/Shared/_DeferredStyles.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Shared/_DeferredStyles.cshtml
@@ -1,4 +1,3 @@
-@inject IThemesService _themes
 
 @* ADD PRELOAD STYLES HERE *@
 

--- a/projects/Hood.UI.Bootstrap4/UI/Shared/_Header_Menu_Account.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Shared/_Header_Menu_Account.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @model HeaderModel
 @{
 }

--- a/projects/Hood.UI.Bootstrap4/UI/Shared/_Header_Menu_Account.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Shared/_Header_Menu_Account.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @model HeaderModel
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 <nav class="modal fade modal-left" id="account-menu" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog modal-blade" role="document">

--- a/projects/Hood.UI.Bootstrap4/UI/Shared/_Header_Menu_Main.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Shared/_Header_Menu_Main.cshtml
@@ -1,7 +1,5 @@
 @inject IContentRepository _content
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
-    var path = Context.Request.Path.ToString().ToLower();
 }
 <ul class="navbar-nav mr-auto">
     <li class="nav-item active">

--- a/projects/Hood.UI.Bootstrap4/UI/Shared/_Header_Menu_Main.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Shared/_Header_Menu_Main.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
 }
 <ul class="navbar-nav mr-auto">

--- a/projects/Hood.UI.Bootstrap4/UI/Shared/_Header_Menu_Mobile.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Shared/_Header_Menu_Mobile.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @model HeaderModel
 @{
     BasicSettings _basicSettings = Engine.Settings.Basic;

--- a/projects/Hood.UI.Bootstrap4/UI/Shared/_Metas.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Shared/_Metas.cshtml
@@ -1,5 +1,4 @@
 @{ 
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     SeoSettings _seoSettings = Engine.Settings.Seo;
     var OgTitle = _seoSettings.OgTitle.IsSet() ? _seoSettings.OgTitle : ViewData["Title"];
     var OgImageUrl = _seoSettings.OgImageUrl.IsSet() ? _seoSettings.OgImageUrl : "http://placehold.it/1200x630";

--- a/projects/Hood.UI.Bootstrap4/UI/Shared/_Styles.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Shared/_Styles.cshtml
@@ -1,3 +1,2 @@
-@inject IThemesService _themes
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/hoodcms@4.1.6/css/styles.bs4.min.css">

--- a/projects/Hood.UI.Bootstrap4/UI/Templates/_Blank.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Templates/_Blank.cshtml
@@ -1,6 +1,5 @@
 @{
     Layout = "_Layout_Basic";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood.UI.Bootstrap4/UI/Templates/_Full.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Templates/_Full.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
     Layout = "_Blank";
 }

--- a/projects/Hood.UI.Bootstrap4/UI/Templates/_Full.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Templates/_Full.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @{
     Layout = "_Blank";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood.UI.Bootstrap4/UI/Templates/_Full_with_Hero.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Templates/_Full_with_Hero.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
     Layout = "_Layout";
 }

--- a/projects/Hood.UI.Bootstrap4/UI/Templates/_Full_with_Hero.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Templates/_Full_with_Hero.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @{
     Layout = "_Layout";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood.UI.Core/BaseUI/Account/Login.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Account/Login.cshtml
@@ -1,5 +1,4 @@
 @model LoginViewModel
-@inject IContentRepository _content
 @{
     ViewData["Title"] = "Sign in";
 

--- a/projects/Hood.UI.Core/BaseUI/Account/Register.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Account/Register.cshtml
@@ -1,5 +1,4 @@
 @model PasswordRegisterViewModel
-@inject IContentRepository _content
 @{
     ViewData["Title"] = "Create an Account";
 

--- a/projects/Hood.UI.Core/BaseUI/Account/RegistrationClosed.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Account/RegistrationClosed.cshtml
@@ -1,5 +1,4 @@
 @model MagicLoginViewModel
-@inject IContentRepository _content
 @{
     ViewData["Title"] = "Registration Closed";
 

--- a/projects/Hood.UI.Core/BaseUI/Home/Feed.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Home/Feed.cshtml
@@ -17,12 +17,6 @@
     }
 
     SeoSettings _seoSettings = Engine.Settings.Seo;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 
 }
 @section metas {

--- a/projects/Hood.UI.Core/BaseUI/Home/Feed.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Home/Feed.cshtml
@@ -2,7 +2,7 @@
 @{
     string title = Model.ContentType.MetaTitle.IsSet() ? Model.ContentType.MetaTitle : Model.ContentType.Title;
     ViewData["Title"] = title;
-    var Feed = "_Feed";
+    string Feed;
 
     @switch (Model.ContentType.BaseName)
     {

--- a/projects/Hood.UI.Core/BaseUI/Home/Index.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Home/Index.cshtml
@@ -1,7 +1,6 @@
 @{
     Layout = "_Layout";
     var _basicSettings = Engine.Settings.Basic;
-    var _integrations = Engine.Settings.Integrations;
     var _seoSettings = Engine.Settings.Seo;
     string description = _basicSettings.Address.ToFormat(AddressFormat.SingleLine);
     string title = "Home - " + _basicSettings.FullTitle;

--- a/projects/Hood.UI.Core/BaseUI/Home/Partials/_Author.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Home/Partials/_Author.cshtml
@@ -1,6 +1,5 @@
 @model ContentModel
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 @if (Model.Content.ShowAuthor)
 {

--- a/projects/Hood.UI.Core/BaseUI/Home/Partials/_Recent.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Home/Partials/_Recent.cshtml
@@ -1,5 +1,4 @@
 @model PagedList<ContentView>
-@inject IContentRepository _content
 @if (Model != null && Model.List.Count > 0)
 {
     @foreach (ContentView content in Model.List)

--- a/projects/Hood.UI.Core/BaseUI/Home/Show.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Home/Show.cshtml
@@ -24,7 +24,7 @@
 
     ViewData["EditUrl"] = Url.Action("Edit", "Content", new { area = "Admin", id = Model.Content.Id });
 
-    var View = "_View";
+    string View;
 
     @switch (Model.ContentType.BaseName)
     {

--- a/projects/Hood.UI.Core/BaseUI/Hood/Maintenance.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Hood/Maintenance.cshtml
@@ -1,6 +1,5 @@
 @{
     var _basicSettings = Engine.Settings.Basic;
-    var _integrations = Engine.Settings.Integrations;
     var _seoSettings = Engine.Settings.Seo;
     string description = _basicSettings.Address.ToFormat(AddressFormat.SingleLine);
     string title = "Undergoing Maintenance - " +  _basicSettings.FullTitle;

--- a/projects/Hood.UI.Core/BaseUI/Layouts/_Layout.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Layouts/_Layout.cshtml
@@ -18,13 +18,13 @@
     @RenderSection("metas", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeCss)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeCss)
 
     <partial name="_Styles" />
     @RenderSection("styles", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.AfterCss)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterCss)
+    @Html.RenderInlineScripts(ResourceLocation.AfterCss)
 
 </head>
 <body class="@(!production ? "dev-mode" : "")">
@@ -60,13 +60,13 @@
 
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeScripts, production)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeScripts)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeScripts)
 
     <partial name="_Scripts_Vendors" />    
     <partial name="_Scripts" />
 
     @Html.RenderScripts(Url, ResourceLocation.AfterScripts, production)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterScripts)
+    @Html.RenderInlineScripts(ResourceLocation.AfterScripts)
 
     @RenderSection("scripts", required: false)
 

--- a/projects/Hood.UI.Core/BaseUI/Layouts/_Layout_Login.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Layouts/_Layout_Login.cshtml
@@ -43,13 +43,13 @@
     </div>
 
     @Html.RenderScripts(Url, ResourceLocation.BeforeScripts)
-    @Html.RenderInlineScripts(Url, ResourceLocation.BeforeScripts)
+    @Html.RenderInlineScripts(ResourceLocation.BeforeScripts)
 
     <partial name="_Scripts_Login" />
     @RenderSection("scripts", required: false)
 
     @Html.RenderScripts(Url, ResourceLocation.AfterScripts)
-    @Html.RenderInlineScripts(Url, ResourceLocation.AfterScripts)
+    @Html.RenderInlineScripts(ResourceLocation.AfterScripts)
 
     @Html.Raw(Engine.Settings.Seo.GoogleAnalytics)
 

--- a/projects/Hood.UI.Core/BaseUI/Property/Index.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Property/Index.cshtml
@@ -5,14 +5,8 @@
 
     SeoSettings _seoSettings = Engine.Settings.Seo;
     BasicSettings _basicSettings = Engine.Settings.Basic;
-    PropertySettings _propertySettings = Engine.Settings.Property;
     IntegrationSettings _plugins = Engine.Settings.Integrations;
 
-    string url = Context.GetSiteUrl(true, true);
-    if (_seoSettings.CanonicalUrl.IsSet())
-    {
-        url = string.Format("{0}{1}", _seoSettings.CanonicalUrl.TrimEnd('/'), Context.Request.Path);
-    }
 
     bool maps = _plugins.GoogleMapsApiKey.IsSet() && (_plugins.EnableGoogleMaps || _plugins.EnableGoogleGeocoding);
 }

--- a/projects/Hood.UI.Core/BaseUI/Property/Modal.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Property/Modal.cshtml
@@ -1,7 +1,5 @@
 @model ShowPropertyModel
 @{
-    SeoSettings _seoSettings = Engine.Settings.Seo;
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     Layout = null;
 }
 <div class="modal-dialog" role="document">

--- a/projects/Hood.UI.Core/BaseUI/Property/Show.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Property/Show.cshtml
@@ -6,16 +6,10 @@
     PropertySettings _propertySettings = Engine.Settings.Property;
 
     var cmTitle = Model.Property.GetMeta("SEO.Meta.Title");
-    var cmDesc = Model.Property.GetMeta("SEO.Meta.Description");
     string metaTitle = Model.Property.Title + " - " + _basicSettings.FullTitle;
-    string metaDesc = Model.Property.ShortDescription;
     if (!cmTitle.GetStringValue().IsNullOrEmpty())
     {
         metaTitle = cmTitle.GetStringValue();
-    }
-    if (!cmDesc.GetStringValue().IsNullOrEmpty())
-    {
-        metaDesc = cmDesc.GetStringValue();
     }
     ViewBag.Title = metaTitle;
     ViewBag.PageTitle = Model.Property.Title;

--- a/projects/Hood.UI.Core/BaseUI/Shared/_ContactForm.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Shared/_ContactForm.cshtml
@@ -1,7 +1,6 @@
 @model ContactFormModel
 @{
     ContactSettings _contactSettings = Engine.Settings.Contact;
-    IntegrationSettings _integrationSettings = Engine.Settings.Integrations;
 }
 <form method="post"
       role="form"

--- a/projects/Hood.UI.Core/BaseUI/Shared/_DeferredStyles.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Shared/_DeferredStyles.cshtml
@@ -1,4 +1,3 @@
-@inject IThemesService _themes
 
 @* ADD PRELOAD STYLES HERE *@
 

--- a/projects/Hood.UI.Core/BaseUI/Shared/_Header_Menu_Account.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Shared/_Header_Menu_Account.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
 }
 <nav class="modal fade modal-left" id="account-menu" tabindex="-1" role="dialog" aria-hidden="true">

--- a/projects/Hood.UI.Core/BaseUI/Shared/_Header_Menu_Account.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Shared/_Header_Menu_Account.cshtml
@@ -1,6 +1,5 @@
 @inject IContentRepository _content
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
 }
 <nav class="modal fade modal-left" id="account-menu" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog modal-blade" role="document">

--- a/projects/Hood.UI.Core/BaseUI/Shared/_Header_Menu_Main.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Shared/_Header_Menu_Main.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
 }
 <ul class="navbar-nav me-auto">

--- a/projects/Hood.UI.Core/BaseUI/Shared/_Header_Menu_Main.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Shared/_Header_Menu_Main.cshtml
@@ -1,7 +1,5 @@
 @inject IContentRepository _content
 @{
-    BasicSettings _basicSettings = Engine.Settings.Basic;
-    var path = Context.Request.Path.ToString().ToLower();
 }
 <ul class="navbar-nav me-auto">
     <li class="nav-item active">

--- a/projects/Hood.UI.Core/BaseUI/Shared/_Header_Menu_Mobile.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Shared/_Header_Menu_Mobile.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
     BasicSettings _basicSettings = Engine.Settings.Basic;
 }

--- a/projects/Hood.UI.Core/BaseUI/Shared/_Metas.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Shared/_Metas.cshtml
@@ -1,5 +1,4 @@
 @{ 
-    BasicSettings _basicSettings = Engine.Settings.Basic;
     SeoSettings _seoSettings = Engine.Settings.Seo;
     var OgTitle = _seoSettings.OgTitle.IsSet() ? _seoSettings.OgTitle : ViewData["Title"];
     var OgImageUrl = _seoSettings.OgImageUrl.IsSet() ? _seoSettings.OgImageUrl : "http://placehold.it/1200x630";

--- a/projects/Hood.UI.Core/BaseUI/Shared/_Styles.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Shared/_Styles.cshtml
@@ -1,4 +1,3 @@
-@inject IThemesService _themes
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 <environment exclude="Production">
     <link rel="stylesheet" href="@Engine.Resource("/src/css/app.css")" asp-append-version="true">

--- a/projects/Hood.UI.Core/BaseUI/Shared/_Styles_Login.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Shared/_Styles_Login.cshtml
@@ -1,4 +1,3 @@
-@inject IThemesService _themes
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@simonwep/pickr/dist/themes/monolith.min.css" />
 <environment exclude="Production">

--- a/projects/Hood.UI.Core/BaseUI/Templates/_Blank.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Templates/_Blank.cshtml
@@ -1,6 +1,5 @@
 @{
     Layout = "_Layout";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
 @RenderSection("styles", required: false)

--- a/projects/Hood.UI.Core/BaseUI/Templates/_Contact.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Templates/_Contact.cshtml
@@ -2,7 +2,6 @@
     BasicSettings _basicSettings  = Engine.Settings.Basic;
     IntegrationSettings _plugins = Engine.Settings.Integrations;
     Layout = "_Layout";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood.UI.Core/BaseUI/Templates/_Full.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Templates/_Full.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
     Layout = "_Blank";
 }

--- a/projects/Hood.UI.Core/BaseUI/Templates/_Full.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Templates/_Full.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @{
     Layout = "_Blank";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood.UI.Core/BaseUI/Templates/_Full_with_Hero.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Templates/_Full_with_Hero.cshtml
@@ -1,4 +1,3 @@
-@inject IContentRepository _content
 @{
     Layout = "_Layout";
 }

--- a/projects/Hood.UI.Core/BaseUI/Templates/_Full_with_Hero.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Templates/_Full_with_Hero.cshtml
@@ -1,7 +1,6 @@
 @inject IContentRepository _content
 @{
     Layout = "_Layout";
-    Content currentContent = ViewData["Content"] as Content;
 }
 @section styles {
     @RenderSection("styles", required: false)

--- a/projects/Hood/Controllers/AccountController.cs
+++ b/projects/Hood/Controllers/AccountController.cs
@@ -1,7 +1,4 @@
 ﻿namespace Hood.Web.Controllers
 {
-    public class AccountController : Hood.BaseControllers.AccountController
-    {
-        public AccountController() { }
-    }
+    public class AccountController : Hood.BaseControllers.AccountController { }
 }

--- a/projects/Hood/Controllers/ErrorController.cs
+++ b/projects/Hood/Controllers/ErrorController.cs
@@ -1,7 +1,4 @@
 ﻿namespace Hood.Web.Controllers
 {
-    public class ErrorController : Hood.BaseControllers.ErrorController
-    {
-        public ErrorController() { }
-    }
+    public class ErrorController : Hood.BaseControllers.ErrorController { }
 }

--- a/projects/Hood/Controllers/HomeController.cs
+++ b/projects/Hood/Controllers/HomeController.cs
@@ -1,7 +1,4 @@
 ﻿namespace Hood.Web.Controllers
 {
-    public class HomeController : Hood.BaseControllers.ErrorController
-    {
-        public HomeController() { }
-    }
+    public class HomeController : Hood.BaseControllers.ErrorController { }
 }

--- a/projects/Hood/Controllers/HoodController.cs
+++ b/projects/Hood/Controllers/HoodController.cs
@@ -1,7 +1,4 @@
 ﻿namespace Hood.Web.Controllers
 {
-    public class HoodController : Hood.BaseControllers.HoodController
-    {
-        public HoodController() { }
-    }
+    public class HoodController : Hood.BaseControllers.HoodController { }
 }

--- a/projects/Hood/Controllers/PropertyController.cs
+++ b/projects/Hood/Controllers/PropertyController.cs
@@ -1,7 +1,4 @@
 ﻿namespace Hood.Web.Controllers
 {
-    public class PropertyController : Hood.BaseControllers.PropertyController
-    {
-        public PropertyController() { }
-    }
+    public class PropertyController : Hood.BaseControllers.PropertyController { }
 }


### PR DESCRIPTION
## HOOD-78 — remaining InspectCode categories: all re-enabled, all fixed

Completes HOOD-78. With PR #71's four categories already merged, this lands the remaining six — the `.editorconfig` "Known code smells" suppression block is now **empty and deleted**; every parked category from HOOD-62 is enforced by the CI gate.

One commit per category, each verified (build 0 warnings, 12/12 tests, gate green):

| Commit | Category | Findings | Approach |
|---|---|---|---|
| `d08dd96e` | InvalidXmlDocComment | 30 | Stale/copy-pasted doc tags corrected |
| `ed1eb608` | UnusedVariable + NotAccessedVariable | 172 | Dead locals deleted; side-effectful initialisers keep the call (guards commented) |
| `5394a345` | RedundantAssignment | 48 | Dead initial values → declare-only / merged |
| `29756a6f` | EmptyConstructor | 48 | All sole-ctors — deletion is semantics-identical |
| `d7da6c21` | UnusedMember/Field/Param **.Local** | 113 | 85 unused `@inject`s, 12 never-read DI fields (+ctor params), dead private code |
| `37fbc6e6` | UnusedParameter.**Global** | 27 | 20 dead public-API params removed (v7 major); 7 documented suppressions where the contract is right and the impl is a stub |

### Real bugs found by the sweep
- **`Country.IsEurope` always returned false** — `europe.ForEach(e => e = e.ToLower())` is a no-op on the lambda parameter, then a case-sensitive `Contains` against lowercased input. Now `OrdinalIgnoreCase`.
- **`Country` ctor typo** — `Iso3 = iso2;` silently discarded the `iso3` argument; every Country carried its 2-letter code in `Iso3`.
- **`AddressService`** — lazy geocoder result was `Count()`'d twice + `First()`'d; each enumeration could re-issue the HTTP geocode call. Materialised. *(landed in #71's enumeration commit)*

### ⚠️ BREAKING CHANGES (for the v7 release notes)

**Consumer `Startup.cs`:**
- `ConfigureHoodCore(config)` / `ConfigureHoodApi(config)` — `env` parameter removed
- `ConfigureCache()` / `UseHoodDefaultRoutes()` — `config` parameter removed

**Consumer themes/layouts:**
- `@Html.RenderInlineScripts(Url, loc)` → `@Html.RenderInlineScripts(loc)` — custom `_Layout.cshtml` files copied from Hood call this 4×
- `IPageBuilder.GenerateInlineScripts` — `IUrlHelper` removed

**Interfaces (implementers + callers):**
- `IContentRepository.GetContent[View]ByIdAsync` — `track` removed
- `IPropertyRepository.GetProperty[View]ByIdAsync` — `nocache` removed
- `IMediaManager.GetCleanFilename` — `path` removed; `ProcessUpload(Stream,…)` — `size` removed
- `IPropertyImporter.RunUpdate` — `HttpContext` removed

**Public constructors (DI adapts; manual `new` / subclasses break):**
`MediaManager(IConfiguration)`, `SettingsRepository(db, cache)`, `RazorViewRenderer(viewEngine, tempData)`, `ContentRepository`, `ContentByTypeCache`, `InstallController`, `RecapcthaTagHelper(IHtmlHelper)`, `ScriptTagHelper(IHtmlHelper)` — each lost a never-read parameter.

**Protected/override surface:**
- `AccountController.SendVerificationEmail(user, returnUrl)` — `userId` removed
- `ContentCategoryCache.AdminContentCategoryTree` — `contentType` removed
- *(from merged PR #71)* `PagedList<T>.PageIndex` de-virtualised — subclass overrides break

**Behaviour changes (bug fixes, no signature change):**
- `Country.IsEurope` now returns `true` for European countries (was always `false`)
- `Country.Iso3` now holds the real 3-letter code (was the 2-letter code via a ctor typo)

*(The 48 deleted empty constructors are NOT breaking — all were sole constructors, the compiler emits identical defaults.)*

Closes HOOD-78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

### Bug fixes from e2e testing (HOOD-81, HOOD-82)

Full e2e (container rebuild from `down -v`, fresh + baseline DBs) surfaced two pre-existing bugs, fixed here in `8d962171`:

- **HOOD-81 — fresh-install deadlock**: a schema-complete but unseeded DB was unusable (`/install` bounced to `/`, which 500'd on null settings). New `Engine.Services.Seeded` (keyed off the `Hood.Settings.SiteOwner` marker `Seed()` writes); the `[Installed]` filter and `InstallController` now gate on `Installed && Seeded`; the content caches null-guard unseeded settings. Verified: fresh DB → everything routes to `/install` (200); seeded DB → site renders, `/install` bounces home.
- **HOOD-82 — stale content-type caches**: enabling a content type 500'd the admin content area (`KeyNotFoundException`) until restart. `SettingsRepository.Set` now fires `OptionsChanged` (the event existed with no trigger and no subscribers), both caches subscribe to it, and the type lookups degrade gracefully via `TryGetValue`.

Closes HOOD-81. Closes HOOD-82.
