### PR TITLE
HOOD-105 - Restructure SQL scripts to explicit version-folder + sequence ordering

### DIFF
--- a/projects/Hood.Core/Hood.Core.csproj
+++ b/projects/Hood.Core/Hood.Core.csproj
@@ -53,14 +53,16 @@
     <PackageReference Include="unsplasharp.api" Version="0.7.0" />
   </ItemGroup>
   <!-- The repo-root sql tier scripts are embedded so the Hood.Core NuGet carries its own schema.
-       One glob; DbUp runs them in LogicalName (= path) order, and the tier/folder names already sort
-       into apply order (6.1 -> 7.0; within 7.0: contexts -> update -> views). Excluded: latest.sql
-       (the assembled fresh-install convenience file), the 6.0 baseline install scripts (the runner
-       upgrades *from* 6.0, it doesn't install it), and the Auth0 backend (alternative, not standard). -->
+       One glob; DbUp applies them in LogicalName order. Scripts live in zero-padded version folders
+       (MM.mm.pp) with a gapped numeric sequence per file (SS-<name>.sql, e.g.
+       07.00.00/50-update-from-6.1.sql) so apply order is explicit and never relies on alphabetical
+       accidents. Every component is padded so it sorts ordinally (07 before a future 10). Excluded:
+       latest.sql (the assembled fresh-install convenience file) and the Auth0 backend scripts (the
+       alternative backend, applied by the consumer, not the standard-Identity runner path). -->
   <ItemGroup>
     <EmbeddedResource
       Include="$(MSBuildThisFileDirectory)../../sql/**/*.sql"
-      Exclude="$(MSBuildThisFileDirectory)../../sql/latest.sql;$(MSBuildThisFileDirectory)../../sql/6.0/**/*.sql;$(MSBuildThisFileDirectory)../../sql/7.0/contexts/Auth0.sql;$(MSBuildThisFileDirectory)../../sql/7.0/views/HoodAuth0UserProfiles.sql"
+      Exclude="$(MSBuildThisFileDirectory)../../sql/latest.sql;$(MSBuildThisFileDirectory)../../sql/07.00.00/35-context-auth0.sql;$(MSBuildThisFileDirectory)../../sql/07.00.00/95-view-auth0userprofiles.sql"
     >
       <LogicalName>Hood.Core.SchemaScripts.%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
     </EmbeddedResource>

--- a/readme.md
+++ b/readme.md
@@ -87,12 +87,12 @@ Your own project SQL rides the same path via `--scripts <folder>` (applied after
 
 **Fresh install** — create the database, then execute `/sql/latest.sql` (standard ASP.NET Identity backend).
 
-**Upgrade** — run the `update.sql` for each tier above your current version, in order:
+**Upgrade** — run the upgrade-delta scripts for each tier above your current version, in folder-then-filename order (the `MM.mm.pp/SS` key is the apply order):
 
 | You're on | Run, in order |
 |---|---|
-| `6.0.x` | `/sql/6.1/update.sql` → `/sql/7.0/update.sql` → the `/sql/7.0/views/*` scripts |
-| `6.1.x` | `/sql/7.0/update.sql` → the `/sql/7.0/views/*` scripts |
+| `6.0.x` | `/sql/06.01.00/10-update-from-6.0.sql` → `/sql/07.00.00/50-update-from-6.1.sql` → the `/sql/07.00.00/*-view-*.sql` scripts |
+| `6.1.x` | `/sql/07.00.00/50-update-from-6.1.sql` → the `/sql/07.00.00/*-view-*.sql` scripts |
 
 The deltas are small and drop no data-bearing columns — see [`sql/README.md`](sql/README.md) for
 exactly what each tier changes.

--- a/sql/06.01.00/10-update-from-6.0.sql
+++ b/sql/06.01.00/10-update-from-6.0.sql
@@ -1,3 +1,4 @@
+-- Apply key 06.01.00/10 | Hood v6.1.0 (6.0.x -> 6.1 upgrade delta). Embedded; applied by hood-schema (DbUp) in LogicalName order.
 -- =============================================================================
 -- Hood CMS — 6.0.x -> 6.1.x upgrade delta (structural)
 -- =============================================================================

--- a/sql/07.00.00/10-context-content.sql
+++ b/sql/07.00.00/10-context-content.sql
@@ -1,3 +1,4 @@
+-- Apply key 07.00.00/10 | Hood v7.0.0 - Content context. Embedded; applied by hood-schema (DbUp) in LogicalName order.
 -- Content tables — idempotent: the whole block runs only on a database that doesn't
 -- already have it. DbUp journals this script; no EF migration-history table is used.
 IF OBJECT_ID(N'[HoodContent]', 'U') IS NULL

--- a/sql/07.00.00/20-context-hooddb.sql
+++ b/sql/07.00.00/20-context-hooddb.sql
@@ -1,3 +1,4 @@
+-- Apply key 07.00.00/20 | Hood v7.0.0 - HoodDb context. Embedded; applied by hood-schema (DbUp) in LogicalName order.
 -- HoodDb tables — idempotent: the whole block runs only on a database that doesn't
 -- already have it. DbUp journals this script; no EF migration-history table is used.
 IF OBJECT_ID(N'[HoodOptions]', 'U') IS NULL

--- a/sql/07.00.00/30-context-identity.sql
+++ b/sql/07.00.00/30-context-identity.sql
@@ -1,3 +1,4 @@
+-- Apply key 07.00.00/30 | Hood v7.0.0 - Identity context (standard ASP.NET Identity backend). Embedded; applied by hood-schema (DbUp) in LogicalName order.
 -- Identity tables — idempotent: the whole block runs only on a database that doesn't
 -- already have it. DbUp journals this script; no EF migration-history table is used.
 IF OBJECT_ID(N'[AspNetRoles]', 'U') IS NULL

--- a/sql/07.00.00/35-context-auth0.sql
+++ b/sql/07.00.00/35-context-auth0.sql
@@ -1,3 +1,4 @@
+-- Apply key 07.00.00/35 | Hood v7.0.0 - Auth0 context (ALTERNATIVE backend; NOT embedded - the consumer applies this instead of the Identity context).
 -- Auth0 tables — idempotent: the whole block runs only on a database that doesn't
 -- already have it. DbUp journals this script; no EF migration-history table is used.
 IF OBJECT_ID(N'[AspNetAuth0Identities]', 'U') IS NULL

--- a/sql/07.00.00/40-context-property.sql
+++ b/sql/07.00.00/40-context-property.sql
@@ -1,3 +1,4 @@
+-- Apply key 07.00.00/40 | Hood v7.0.0 - Property context. Embedded; applied by hood-schema (DbUp) in LogicalName order.
 -- Property tables — idempotent: the whole block runs only on a database that doesn't
 -- already have it. DbUp journals this script; no EF migration-history table is used.
 IF OBJECT_ID(N'[HoodProperties]', 'U') IS NULL

--- a/sql/07.00.00/50-update-from-6.1.sql
+++ b/sql/07.00.00/50-update-from-6.1.sql
@@ -1,3 +1,4 @@
+-- Apply key 07.00.00/50 | Hood v7.0.0 (6.1.x -> 7.0 upgrade delta). Embedded; applied by hood-schema (DbUp) in LogicalName order.
 -- =============================================================================
 -- Hood CMS — v6.1.x  ->  v7.0 upgrade delta
 -- =============================================================================

--- a/sql/07.00.00/70-view-contentviews.sql
+++ b/sql/07.00.00/70-view-contentviews.sql
@@ -1,3 +1,4 @@
+-- Apply key 07.00.00/70 | Hood v7.0.0 - HoodContentViews reporting view (idempotent DROP/CREATE). Embedded; applied by hood-schema (DbUp) in LogicalName order.
 IF EXISTS(select * FROM sys.views where name = 'HoodContentViews') DROP VIEW HoodContentViews
 GO
 CREATE VIEW HoodContentViews AS

--- a/sql/07.00.00/80-view-propertyviews.sql
+++ b/sql/07.00.00/80-view-propertyviews.sql
@@ -1,3 +1,4 @@
+-- Apply key 07.00.00/80 | Hood v7.0.0 - HoodPropertyViews reporting view (idempotent DROP/CREATE). Embedded; applied by hood-schema (DbUp) in LogicalName order.
 IF EXISTS(select * FROM sys.views where name = 'HoodPropertyViews') DROP VIEW HoodPropertyViews
 GO
 CREATE VIEW HoodPropertyViews AS

--- a/sql/07.00.00/90-view-userprofiles.sql
+++ b/sql/07.00.00/90-view-userprofiles.sql
@@ -1,3 +1,4 @@
+-- Apply key 07.00.00/90 | Hood v7.0.0 - HoodUserProfiles reporting view (idempotent DROP/CREATE). Embedded; applied by hood-schema (DbUp) in LogicalName order.
 IF EXISTS(select * FROM sys.views where name = 'HoodUserProfiles') DROP VIEW HoodUserProfiles
 GO
 CREATE VIEW HoodUserProfiles AS

--- a/sql/07.00.00/95-view-auth0userprofiles.sql
+++ b/sql/07.00.00/95-view-auth0userprofiles.sql
@@ -1,3 +1,4 @@
+-- Apply key 07.00.00/95 | Hood v7.0.0 - HoodAuth0UserProfiles view (ALTERNATIVE backend; NOT embedded - the consumer applies this instead of HoodUserProfiles).
 IF EXISTS(select * FROM sys.views where name = 'HoodAuth0UserProfiles') DROP VIEW HoodAuth0UserProfiles
 GO
 CREATE VIEW HoodAuth0UserProfiles AS

--- a/sql/README.md
+++ b/sql/README.md
@@ -30,7 +30,7 @@ sqlcmd -S <server> -d <db> -i sql/latest.sql
 
 `sql/latest.sql` creates all tables and the reporting views for the **standard ASP.NET Identity** backend.
 
-> Using the alternative **Auth0** backend instead? It's mutually exclusive with standard Identity (it recreates `AspNetUsers`). Apply `sql/7.0/contexts/Auth0.sql` + `sql/7.0/views/HoodAuth0UserProfiles.sql` instead of the Identity parts.
+> Using the alternative **Auth0** backend instead? It's mutually exclusive with standard Identity (it recreates `AspNetUsers`). Apply `sql/07.00.00/35-context-auth0.sql` + `sql/07.00.00/95-view-auth0userprofiles.sql` instead of the Identity parts.
 
 ## Upgrading an existing database
 
@@ -38,15 +38,17 @@ Prefer the runner above — it does fresh + upgrade in one step. To upgrade by h
 
 ```bash
 # 6.0.x only — bring the database to the 6.1 baseline first:
-sqlcmd -S <server> -d <db> -i sql/6.1/update.sql
+sqlcmd -S <server> -d <db> -i sql/06.01.00/10-update-from-6.0.sql
 # 6.0.x and 6.1.x — the 7.0 delta + views:
-sqlcmd -S <server> -d <db> -i sql/7.0/update.sql
-sqlcmd -S <server> -d <db> -i sql/7.0/views/HoodContentViews.sql
-sqlcmd -S <server> -d <db> -i sql/7.0/views/HoodUserProfiles.sql
-sqlcmd -S <server> -d <db> -i sql/7.0/views/HoodPropertyViews.sql
+sqlcmd -S <server> -d <db> -i sql/07.00.00/50-update-from-6.1.sql
+sqlcmd -S <server> -d <db> -i sql/07.00.00/70-view-contentviews.sql
+sqlcmd -S <server> -d <db> -i sql/07.00.00/80-view-propertyviews.sql
+sqlcmd -S <server> -d <db> -i sql/07.00.00/90-view-userprofiles.sql
 ```
 
-### What `sql/6.1/update.sql` does (6.0.x → 6.1)
+(Apply scripts in folder-then-filename order — the `MM.mm.pp/SS` key **is** the apply order.)
+
+### What `06.01.00/10-update-from-6.0.sql` does (6.0.x → 6.1)
 
 Idempotent + forward-only structural cleanup that 6.1 applied:
 
@@ -54,7 +56,7 @@ Idempotent + forward-only structural cleanup that 6.1 applied:
 - Drops the removed `HoodAddresses` table. **Destructive** — v7 has no such table; a 6.0 site with address data should migrate it out first (it's empty in the stock install).
 - Drops columns removed in 6.1: `AspNetUsers.Latitude` / `.Longitude` and `HoodContent.Notes` / `.SystemNotes` / `.UserVars` (nothing in v7 reads them).
 
-### What `sql/7.0/update.sql` does (6.1.x → 7.0)
+### What `07.00.00/50-update-from-6.1.sql` does (6.1.x → 7.0)
 
 The v7 delta is small and **drops no data-bearing base-table columns**:
 
@@ -63,7 +65,7 @@ The v7 delta is small and **drops no data-bearing base-table columns**:
 - Drops the unused `__HoodMigrationHistory` table (version is tracked in `HoodOptions`).
 - Stamps `HoodOptions['Hood.Version'] = '7.0.0'`.
 
-(The reporting views are applied separately — the `sql/7.0/views/*` scripts, idempotent DROP/CREATE — so they're shared by fresh installs, upgrades and the runner.)
+(The reporting views are applied separately — the `*-view-*.sql` scripts, idempotent DROP/CREATE — so they're shared by fresh installs, upgrades and the runner.)
 
 Consumers on the 6.1.x baseline take a **clean, zero-data-loss** upgrade — verified that nothing reads any removed field.
 
@@ -75,23 +77,34 @@ Consumers on the 6.1.x baseline take a **clean, zero-data-loss** upgrade — ver
    cd projects/Hood.Core
    dotnet ef migrations add <name> --context <Context> --output-dir Migrations/<Folder>
    ```
-3. Regenerate the idempotent per-context DDL and reassemble `latest.sql`:
+3. Regenerate the idempotent per-context DDL (overwrite the context's existing numbered script) and reassemble `latest.sql`:
    ```bash
-   dotnet ef migrations script --idempotent --context <Context> -o ../../sql/7.0/contexts/<Folder>.sql
+   dotnet ef migrations script --idempotent --context <Context> -o ../../sql/07.00.00/NN-context-<name>.sql
    ```
-   (Strip the UTF-8 BOM EF writes, and keep the `SET QUOTED_IDENTIFIER ON; SET ANSI_NULLS ON;` preamble at the top of `latest.sql` — the Identity filtered indexes and the views require it.)
-4. Hand-write the matching `update.sql` delta for the new tier and document it in the table above.
+   (Strip the UTF-8 BOM EF writes, re-add the `-- Apply key …` banner line, and keep the `SET QUOTED_IDENTIFIER ON; SET ANSI_NULLS ON;` preamble at the top of `latest.sql` — the Identity filtered indexes and the views require it.)
+4. Hand-write the matching upgrade delta as a **new** `MM.mm.pp/SS-<name>.sql` script (next free sequence, gapped) and document it above.
 
-## Layout
+## Script ordering & layout
+
+Scripts live in **zero-padded version folders** (`MM.mm.pp`) with a **gapped numeric sequence** per file (`SS-<name>.sql`), and that folder-then-sequence key **is** the apply order. Every component is padded (including the major, so `07.00.00` sorts before a future `10.00.00`, and `SS` so `90` sorts after `10`); the sequence is **gapped by 10s** so new scripts can be wedged between existing ones without renumbering. Ordering never relies on alphabetical accidents; the version is carried by the folder + the `-- Apply key …` header banner + the `HoodOptions['Hood.Version']` stamp.
 
 ```
 sql/
-  latest.sql            # full fresh install (standard Identity) — what new databases run
-  7.0/
-    update.sql          # 6.1.x -> 7.0 upgrade delta
-    contexts/*.sql      # per-context table DDL (generated, idempotent)
-    views/*.sql         # the four reporting views (idempotent DROP/CREATE)
-  6.1/
-    update.sql          # 6.0.x -> 6.1 upgrade delta (drop legacy FKs/columns/HoodAddresses)
-  6.0/                  # 6.0 baseline install (reference; the runner upgrades *from* it)
+  latest.sql                            # full fresh install (standard Identity) — what new databases run (NOT embedded in the runner)
+  06.01.00/
+    10-update-from-6.0.sql              # 6.0.x -> 6.1 upgrade delta (drop legacy FKs/columns/HoodAddresses)
+  07.00.00/
+    10-context-content.sql             # per-context table DDL (generated, idempotent)
+    20-context-hooddb.sql
+    30-context-identity.sql            # standard ASP.NET Identity backend
+    35-context-auth0.sql               # ALTERNATIVE Auth0 backend — NOT embedded; consumer applies instead of Identity
+    40-context-property.sql
+    50-update-from-6.1.sql             # 6.1.x -> 7.0 upgrade delta
+    60-…                               # (reserved) convergence delta — HOOD-104
+    70-view-contentviews.sql           # reporting views (idempotent DROP/CREATE)
+    80-view-propertyviews.sql
+    90-view-userprofiles.sql
+    95-view-auth0userprofiles.sql      # ALTERNATIVE Auth0 backend — NOT embedded; consumer applies instead of userprofiles
 ```
+
+The runner embeds these from `Hood.Core` (`Hood.Core.csproj`) and applies them by `LogicalName` order — i.e. the `MM.mm.pp/SS` key — **excluding** `latest.sql` and the two Auth0-backend scripts. Apply order: contexts → update → (`07.00.00/60` convergence delta, when present) → views.


### PR DESCRIPTION
## Overview

The `hood-schema` runner applies embedded SQL scripts in DbUp `LogicalName` order, which previously worked only by the alphabetical accident that `contexts < update < views`. Semver folder names are not ordinally sortable (`7.10` sorts before `7.2`), and any ad-hoc script (e.g. a future convergence delta) relied on luck to land in the right place. This replaces the incidental ordering with an explicit, ordinally-sortable scheme — done now, before `7.0.0` GA, while it's a free change.

Closes HOOD-105.

---

## What Changed and Why

**Explicit ordering scheme.** SQL scripts now live in **zero-padded version folders** (`MM.mm.pp/`) holding a **gapped numeric sequence** per file (`SS-<name>.sql`) — e.g. `sql/07.00.00/50-update-from-6.1.sql`. The `MM.mm.pp/SS` key *is* the apply order; every component is padded so it sorts ordinally (`07.00.00` before a future `10.00.00`, `90` after `10`), and the sequence is gapped by 10s so scripts can be inserted without renumbering. `07.00.00/60` is reserved for the upcoming convergence delta (HOOD-104).

**Embed glob.** `Hood.Core.csproj` embeds the scripts via `LogicalName` = the folder + filename; `latest.sql` and the two Auth0-backend scripts stay excluded (consumer-applied). Verified against the built assembly that the 9 embedded scripts resolve in correct numeric order.

**Per-script header banners.** Each script carries an `-- Apply key MM.mm.pp/SS …` banner so the version/order is self-documenting, not folder-sort-dependent.

**Docs.** `sql/README.md` and the root `readme.md` updated to the new layout, by-hand `sqlcmd` paths, and regeneration steps.

This change is naming/ordering only — **no SQL content, schema, or runtime behaviour changes** (the convergence work itself is HOOD-104).

---

## Tests

- Full solution build: clean.
- CSharpier format check: clean (no C# touched).
- `Hood.Tests`: 30 passed, 7 skipped (DB-backed `SkippableFact`s), 0 failed.
- Verified embedded `SchemaScripts.*` resource names + ordering directly from the built `Hood.Core.dll`.

---

## Breaking Changes

⚠️ **Schema-script names and paths changed.** The embedded script `LogicalName`s and the on-disk `sql/` layout are renamed. DbUp journals by script name, so a database that already applied the old-named scripts will **re-run** the renamed scripts (new `dbo.SchemaVersions` rows). Every script is idempotent + guarded, so re-running is a no-op — but operators applying scripts by hand must use the new paths (see `sql/README.md`). Landed pre-`7.0.0` GA, before any released consumer depends on the journal.

---

## Testing Plan

- [ ] `hood-schema upgrade` against a fresh database → all scripts apply in order, lands on v7.
- [ ] `hood-schema upgrade` re-run → clean no-op.
- [ ] By-hand `sqlcmd` upgrade using the new `sql/07.00.00/*` paths.