### PR TITLE
HOOD-104 - Converge upgraded schema with fresh + schema-parity regression test

### DIFF
--- a/projects/Hood.Core/Contexts/ContentContext.cs
+++ b/projects/Hood.Core/Contexts/ContentContext.cs
@@ -21,6 +21,10 @@ namespace Hood.Contexts
             base.OnModelCreating(builder);
 
             builder.Entity<Content>().ToTable("HoodContent");
+            // User-reference columns are bounded + indexed (the shape upgraded DBs already carry) so
+            // fresh installs converge with them; nvarchar(max) cannot be indexed.
+            builder.Entity<Content>().Property(c => c.AuthorId).HasMaxLength(450);
+            builder.Entity<Content>().HasIndex(c => c.AuthorId);
 
             builder.Entity<ContentMedia>().ToTable("HoodContentMedia");
             builder

--- a/projects/Hood.Core/Contexts/HoodDbContext.cs
+++ b/projects/Hood.Core/Contexts/HoodDbContext.cs
@@ -39,6 +39,9 @@ namespace Hood.Models
 
             builder.Entity<Option>().ToTable("HoodOptions");
             builder.Entity<Log>().ToTable("HoodLogs");
+            // UserId bounded + indexed to converge with the shape upgraded DBs carry.
+            builder.Entity<Log>().Property(l => l.UserId).HasMaxLength(450);
+            builder.Entity<Log>().HasIndex(l => l.UserId);
 
             // Media
             builder.Entity<MediaObject>().ToTable("HoodMedia");

--- a/projects/Hood.Core/Contexts/IdentityContext.cs
+++ b/projects/Hood.Core/Contexts/IdentityContext.cs
@@ -28,6 +28,12 @@ namespace Hood.Contexts
         {
             base.OnModelCreating(builder);
 
+            // AspNetRoles carries a nullable RemoteId for BOTH auth backends so the schema is one
+            // shape regardless of backend. The Auth0 backend maps local roles to Auth0 platform roles via it; the
+            // standard backend never reads it, so it's a shadow property (no CLR member) — the column
+            // exists (always null on standard installs) and AspNetRoles is one shape across backends.
+            builder.Entity<IdentityRole>().Property<string>("RemoteId");
+
             builder.Entity<ApplicationUser>(typeBuilder =>
             {
                 typeBuilder.ToTable("AspNetUsers");

--- a/projects/Hood.Core/Contexts/PropertyContext.cs
+++ b/projects/Hood.Core/Contexts/PropertyContext.cs
@@ -20,6 +20,9 @@ namespace Hood.Contexts
             base.OnModelCreating(builder);
 
             builder.Entity<PropertyListing>().ToTable("HoodProperties");
+            // AgentId bounded + indexed to converge with the shape upgraded DBs carry.
+            builder.Entity<PropertyListing>().Property(p => p.AgentId).HasMaxLength(450);
+            builder.Entity<PropertyListing>().HasIndex(p => p.AgentId);
             // HasSentinel(-1) so a real (0,0) coordinate is INSERTed explicitly instead of being
             // treated as "unset" and omitted under the EF Core 8+ sentinel rules (HOOD-48 #4).
             // The DB-side DEFAULT (0.0) is unchanged, so there is no schema delta.

--- a/projects/Hood.Core/Migrations/Content/20260611193850_v7_baseline.Designer.cs
+++ b/projects/Hood.Core/Migrations/Content/20260611193850_v7_baseline.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Hood.Core.Migrations.Content
 {
     [DbContext(typeof(ContentContext))]
-    [Migration("20260602172831_v7_baseline")]
+    [Migration("20260611193850_v7_baseline")]
     partial class v7_baseline
     {
         /// <inheritdoc />
@@ -37,7 +37,8 @@ namespace Hood.Core.Migrations.Content
                         .HasColumnType("bit");
 
                     b.Property<string>("AuthorId")
-                        .HasColumnType("nvarchar(max)");
+                        .HasMaxLength(450)
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Body")
                         .HasColumnType("nvarchar(max)");
@@ -96,6 +97,8 @@ namespace Hood.Core.Migrations.Content
                         .HasColumnType("int");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("AuthorId");
 
                     b.ToTable("HoodContent", (string)null);
                 });

--- a/projects/Hood.Core/Migrations/Content/20260611193850_v7_baseline.cs
+++ b/projects/Hood.Core/Migrations/Content/20260611193850_v7_baseline.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -35,7 +35,11 @@ namespace Hood.Core.Migrations.Content
                     AllowComments = table.Column<bool>(type: "bit", nullable: false),
                     Public = table.Column<bool>(type: "bit", nullable: false),
                     Featured = table.Column<bool>(type: "bit", nullable: false),
-                    AuthorId = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    AuthorId = table.Column<string>(
+                        type: "nvarchar(450)",
+                        maxLength: 450,
+                        nullable: true
+                    ),
                     FeaturedImageJson = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     ShareImageJson = table.Column<string>(type: "nvarchar(max)", nullable: true),
                 },
@@ -162,6 +166,12 @@ namespace Hood.Core.Migrations.Content
                         onDelete: ReferentialAction.Cascade
                     );
                 }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HoodContent_AuthorId",
+                table: "HoodContent",
+                column: "AuthorId"
             );
 
             migrationBuilder.CreateIndex(

--- a/projects/Hood.Core/Migrations/Content/ContentContextModelSnapshot.cs
+++ b/projects/Hood.Core/Migrations/Content/ContentContextModelSnapshot.cs
@@ -34,7 +34,8 @@ namespace Hood.Core.Migrations.Content
                         .HasColumnType("bit");
 
                     b.Property<string>("AuthorId")
-                        .HasColumnType("nvarchar(max)");
+                        .HasMaxLength(450)
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Body")
                         .HasColumnType("nvarchar(max)");
@@ -93,6 +94,8 @@ namespace Hood.Core.Migrations.Content
                         .HasColumnType("int");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("AuthorId");
 
                     b.ToTable("HoodContent", (string)null);
                 });

--- a/projects/Hood.Core/Migrations/HoodDb/20260611194043_v7_baseline.Designer.cs
+++ b/projects/Hood.Core/Migrations/HoodDb/20260611194043_v7_baseline.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Hood.Core.Migrations.HoodDb
 {
     [DbContext(typeof(HoodDbContext))]
-    [Migration("20260602173244_v7_baseline")]
+    [Migration("20260611194043_v7_baseline")]
     partial class v7_baseline
     {
         /// <inheritdoc />
@@ -52,9 +52,12 @@ namespace Hood.Core.Migrations.HoodDb
                         .HasColumnType("int");
 
                     b.Property<string>("UserId")
-                        .HasColumnType("nvarchar(max)");
+                        .HasMaxLength(450)
+                        .HasColumnType("nvarchar(450)");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("UserId");
 
                     b.ToTable("HoodLogs", (string)null);
                 });

--- a/projects/Hood.Core/Migrations/HoodDb/20260611194043_v7_baseline.cs
+++ b/projects/Hood.Core/Migrations/HoodDb/20260611194043_v7_baseline.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -22,7 +22,11 @@ namespace Hood.Core.Migrations.HoodDb
                     Title = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Detail = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Type = table.Column<int>(type: "int", nullable: false),
-                    UserId = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    UserId = table.Column<string>(
+                        type: "nvarchar(450)",
+                        maxLength: 450,
+                        nullable: true
+                    ),
                     Source = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     SourceUrl = table.Column<string>(type: "nvarchar(max)", nullable: true),
                 },
@@ -105,6 +109,12 @@ namespace Hood.Core.Migrations.HoodDb
                         onDelete: ReferentialAction.Restrict
                     );
                 }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HoodLogs_UserId",
+                table: "HoodLogs",
+                column: "UserId"
             );
 
             migrationBuilder.CreateIndex(

--- a/projects/Hood.Core/Migrations/HoodDb/HoodDbContextModelSnapshot.cs
+++ b/projects/Hood.Core/Migrations/HoodDb/HoodDbContextModelSnapshot.cs
@@ -49,9 +49,12 @@ namespace Hood.Core.Migrations.HoodDb
                         .HasColumnType("int");
 
                     b.Property<string>("UserId")
-                        .HasColumnType("nvarchar(max)");
+                        .HasMaxLength(450)
+                        .HasColumnType("nvarchar(450)");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("UserId");
 
                     b.ToTable("HoodLogs", (string)null);
                 });

--- a/projects/Hood.Core/Migrations/Identity/20260611193928_v7_baseline.Designer.cs
+++ b/projects/Hood.Core/Migrations/Identity/20260611193928_v7_baseline.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Hood.Core.Migrations.Identity
 {
     [DbContext(typeof(IdentityContext))]
-    [Migration("20260602172828_v7_baseline")]
+    [Migration("20260611193928_v7_baseline")]
     partial class v7_baseline
     {
         /// <inheritdoc />
@@ -28,6 +28,7 @@ namespace Hood.Core.Migrations.Identity
             modelBuilder.Entity("Hood.Models.ApplicationUser", b =>
                 {
                     b.Property<string>("Id")
+                        .ValueGeneratedOnAdd()
                         .HasColumnType("nvarchar(450)");
 
                     b.Property<int>("AccessFailedCount")
@@ -254,6 +255,9 @@ namespace Hood.Core.Migrations.Identity
                     b.Property<string>("NormalizedName")
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
+
+                    b.Property<string>("RemoteId")
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");
 

--- a/projects/Hood.Core/Migrations/Identity/20260611193928_v7_baseline.cs
+++ b/projects/Hood.Core/Migrations/Identity/20260611193928_v7_baseline.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -16,6 +16,7 @@ namespace Hood.Core.Migrations.Identity
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    RemoteId = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Name = table.Column<string>(
                         type: "nvarchar(256)",
                         maxLength: 256,

--- a/projects/Hood.Core/Migrations/Identity/IdentityContextModelSnapshot.cs
+++ b/projects/Hood.Core/Migrations/Identity/IdentityContextModelSnapshot.cs
@@ -25,6 +25,7 @@ namespace Hood.Core.Migrations.Identity
             modelBuilder.Entity("Hood.Models.ApplicationUser", b =>
                 {
                     b.Property<string>("Id")
+                        .ValueGeneratedOnAdd()
                         .HasColumnType("nvarchar(450)");
 
                     b.Property<int>("AccessFailedCount")
@@ -251,6 +252,9 @@ namespace Hood.Core.Migrations.Identity
                     b.Property<string>("NormalizedName")
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
+
+                    b.Property<string>("RemoteId")
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");
 

--- a/projects/Hood.Core/Migrations/Property/20260611194006_v7_baseline.Designer.cs
+++ b/projects/Hood.Core/Migrations/Property/20260611194006_v7_baseline.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Hood.Core.Migrations.Property
 {
     [DbContext(typeof(PropertyContext))]
-    [Migration("20260602172835_v7_baseline")]
+    [Migration("20260611194006_v7_baseline")]
     partial class v7_baseline
     {
         /// <inheritdoc />
@@ -107,7 +107,8 @@ namespace Hood.Core.Migrations.Property
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("AgentId")
-                        .HasColumnType("nvarchar(max)");
+                        .HasMaxLength(450)
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("AgentInfo")
                         .HasColumnType("nvarchar(max)");
@@ -270,6 +271,8 @@ namespace Hood.Core.Migrations.Property
                         .HasColumnType("int");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("AgentId");
 
                     b.ToTable("HoodProperties", (string)null);
                 });

--- a/projects/Hood.Core/Migrations/Property/20260611194006_v7_baseline.cs
+++ b/projects/Hood.Core/Migrations/Property/20260611194006_v7_baseline.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -84,7 +84,11 @@ namespace Hood.Core.Migrations.Property
                     QuickName = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Addressee = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Phone = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    AgentId = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    AgentId = table.Column<string>(
+                        type: "nvarchar(450)",
+                        maxLength: 450,
+                        nullable: true
+                    ),
                     Floors = table.Column<string>(type: "nvarchar(max)", nullable: true),
                 },
                 constraints: table =>
@@ -192,6 +196,12 @@ namespace Hood.Core.Migrations.Property
                         onDelete: ReferentialAction.Restrict
                     );
                 }
+            );
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HoodProperties_AgentId",
+                table: "HoodProperties",
+                column: "AgentId"
             );
 
             migrationBuilder.CreateIndex(

--- a/projects/Hood.Core/Migrations/Property/PropertyContextModelSnapshot.cs
+++ b/projects/Hood.Core/Migrations/Property/PropertyContextModelSnapshot.cs
@@ -104,7 +104,8 @@ namespace Hood.Core.Migrations.Property
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("AgentId")
-                        .HasColumnType("nvarchar(max)");
+                        .HasMaxLength(450)
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("AgentInfo")
                         .HasColumnType("nvarchar(max)");
@@ -267,6 +268,8 @@ namespace Hood.Core.Migrations.Property
                         .HasColumnType("int");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("AgentId");
 
                     b.ToTable("HoodProperties", (string)null);
                 });

--- a/projects/Hood.Tests/SchemaParityTests.cs
+++ b/projects/Hood.Tests/SchemaParityTests.cs
@@ -1,0 +1,232 @@
+using System;
+using System.IO;
+using System.Linq;
+using Hood.Services;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace Hood.Tests
+{
+    /// <summary>
+    /// Schema-parity / convergence guard. Provisions a fresh standard-Identity database via the
+    /// hood-schema runner and asserts the converged shape that an upgraded 6.x database also lands on:
+    /// bounded (nvarchar(450)) + indexed user-reference columns, a universal nullable
+    /// AspNetRoles.RemoteId, and a nullable AspNetUsers.Anonymous. Also checks the convergence delta
+    /// relaxes Anonymous and is idempotent, and that the runner re-run is a clean no-op.
+    ///
+    /// SkippableFact-gated on a reachable SQL Server: runs in CI (DB provisioned), skips locally without
+    /// one. These pins go red on the pre-convergence schema (AuthorId nvarchar(max), no index, no
+    /// RemoteId) and green after, so the drift cannot silently return.
+    ///
+    /// Full from-6.x-baseline upgrade parity (apply a committed 6.x snapshot, upgrade, diff vs fresh)
+    /// needs a 6.x baseline fixture the repo doesn't yet carry — that broader parity is tracked separately.
+    /// </summary>
+    [Collection("Database")]
+    public class SchemaParityTests
+    {
+        private readonly DatabaseFixture _fixture;
+
+        public SchemaParityTests(DatabaseFixture fixture) => _fixture = fixture;
+
+        private string ConnFor(string db) =>
+            new SqlConnectionStringBuilder(_fixture.ConnectionString)
+            {
+                InitialCatalog = db,
+            }.ConnectionString;
+
+        private void DropDatabase(string db)
+        {
+            using var c = new SqlConnection(
+                new SqlConnectionStringBuilder(_fixture.ConnectionString)
+                {
+                    InitialCatalog = "master",
+                }.ConnectionString
+            );
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText =
+                $"IF DB_ID('{db}') IS NOT NULL BEGIN "
+                + $"ALTER DATABASE [{db}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [{db}]; END";
+            cmd.ExecuteNonQuery();
+        }
+
+        private void ProvisionFresh(string db)
+        {
+            DropDatabase(db);
+            var result = new DatabaseDeployService().Deploy(ConnFor(db), null, _ => { });
+            Assert.True(result.Successful, result.Error);
+        }
+
+        private void Exec(string db, string sql)
+        {
+            using var c = new SqlConnection(ConnFor(db));
+            c.Open();
+            foreach (
+                var batch in sql.Split(
+                        new[] { "\nGO\n", "\nGO\r\n", "\r\nGO\r\n" },
+                        StringSplitOptions.RemoveEmptyEntries
+                    )
+                    .Where(b => !string.IsNullOrWhiteSpace(b))
+            )
+            {
+                using var cmd = c.CreateCommand();
+                cmd.CommandText = batch;
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        private T Scalar<T>(string db, string sql)
+        {
+            using var c = new SqlConnection(ConnFor(db));
+            c.Open();
+            using var cmd = c.CreateCommand();
+            cmd.CommandText = sql;
+            var v = cmd.ExecuteScalar();
+            return v == null || v == DBNull.Value ? default : (T)Convert.ChangeType(v, typeof(T));
+        }
+
+        private static string ReadEmbedded(string resourceName)
+        {
+            using var s = typeof(DatabaseDeployService).Assembly.GetManifestResourceStream(
+                resourceName
+            );
+            Assert.NotNull(s);
+            using var r = new StreamReader(s!);
+            return r.ReadToEnd();
+        }
+
+        [SkippableFact]
+        public void Fresh_user_reference_columns_are_bounded_450_and_indexed()
+        {
+            Skip.IfNot(_fixture.Available, _fixture.UnavailableReason);
+            const string db = "HoodParity_UserRef";
+            try
+            {
+                ProvisionFresh(db);
+                foreach (
+                    var (table, col, ix) in new[]
+                    {
+                        ("HoodContent", "AuthorId", "IX_HoodContent_AuthorId"),
+                        ("HoodLogs", "UserId", "IX_HoodLogs_UserId"),
+                        ("HoodProperties", "AgentId", "IX_HoodProperties_AgentId"),
+                    }
+                )
+                {
+                    // nvarchar(max) reports CHARACTER_MAXIMUM_LENGTH = -1; the converged shape is 450.
+                    var maxLen = Scalar<int>(
+                        db,
+                        $"SELECT CHARACTER_MAXIMUM_LENGTH FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='{table}' AND COLUMN_NAME='{col}'"
+                    );
+                    Assert.True(
+                        maxLen == 450,
+                        $"{table}.{col} should be nvarchar(450), was {maxLen}"
+                    );
+
+                    var hasIndex = Scalar<int>(
+                        db,
+                        $"SELECT COUNT(*) FROM sys.indexes WHERE name='{ix}' AND object_id=OBJECT_ID('{table}')"
+                    );
+                    Assert.True(hasIndex == 1, $"index {ix} missing on {table}");
+                }
+            }
+            finally
+            {
+                DropDatabase(db);
+            }
+        }
+
+        [SkippableFact]
+        public void Fresh_AspNetRoles_has_RemoteId_and_Anonymous_is_nullable()
+        {
+            Skip.IfNot(_fixture.Available, _fixture.UnavailableReason);
+            const string db = "HoodParity_Roles";
+            try
+            {
+                ProvisionFresh(db);
+
+                var hasRemoteId = Scalar<int>(
+                    db,
+                    "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='AspNetRoles' AND COLUMN_NAME='RemoteId'"
+                );
+                Assert.True(hasRemoteId == 1, "AspNetRoles.RemoteId should exist on both backends");
+
+                var anonNullable = Scalar<string>(
+                    db,
+                    "SELECT IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='AspNetUsers' AND COLUMN_NAME='Anonymous'"
+                );
+                Assert.Equal("YES", anonNullable);
+            }
+            finally
+            {
+                DropDatabase(db);
+            }
+        }
+
+        [SkippableFact]
+        public void Runner_re_run_is_a_clean_no_op()
+        {
+            Skip.IfNot(_fixture.Available, _fixture.UnavailableReason);
+            const string db = "HoodParity_Idem";
+            try
+            {
+                ProvisionFresh(db);
+                var second = new DatabaseDeployService().Deploy(ConnFor(db), null, _ => { });
+                Assert.True(second.Successful, second.Error);
+                Assert.Empty(second.ScriptsApplied);
+            }
+            finally
+            {
+                DropDatabase(db);
+            }
+        }
+
+        [SkippableFact]
+        public void Converge_delta_relaxes_anonymous_and_is_idempotent()
+        {
+            Skip.IfNot(_fixture.Available, _fixture.UnavailableReason);
+            const string db = "HoodParity_Converge";
+            try
+            {
+                ProvisionFresh(db);
+
+                // Re-create the pre-convergence 6.x shape: Anonymous NOT NULL.
+                Exec(
+                    db,
+                    "UPDATE [AspNetUsers] SET [Anonymous]=0 WHERE [Anonymous] IS NULL;"
+                        + "ALTER TABLE [AspNetUsers] ALTER COLUMN [Anonymous] bit NOT NULL;"
+                );
+                Assert.Equal(
+                    "NO",
+                    Scalar<string>(
+                        db,
+                        "SELECT IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='AspNetUsers' AND COLUMN_NAME='Anonymous'"
+                    )
+                );
+
+                var converge = ReadEmbedded("Hood.Core.SchemaScripts.07.00.00/60-converge.sql");
+                Exec(db, converge);
+                Assert.Equal(
+                    "YES",
+                    Scalar<string>(
+                        db,
+                        "SELECT IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='AspNetUsers' AND COLUMN_NAME='Anonymous'"
+                    )
+                );
+
+                // Idempotent: a second application is a clean no-op.
+                Exec(db, converge);
+                Assert.Equal(
+                    "YES",
+                    Scalar<string>(
+                        db,
+                        "SELECT IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='AspNetUsers' AND COLUMN_NAME='Anonymous'"
+                    )
+                );
+            }
+            finally
+            {
+                DropDatabase(db);
+            }
+        }
+    }
+}

--- a/sql/07.00.00/10-context-content.sql
+++ b/sql/07.00.00/10-context-content.sql
@@ -22,7 +22,7 @@ BEGIN
         [AllowComments] bit NOT NULL,
         [Public] bit NOT NULL,
         [Featured] bit NOT NULL,
-        [AuthorId] nvarchar(max) NULL,
+        [AuthorId] nvarchar(450) NULL,
         [FeaturedImageJson] nvarchar(max) NULL,
         [ShareImageJson] nvarchar(max) NULL,
         CONSTRAINT [PK_HoodContent] PRIMARY KEY ([Id])
@@ -83,4 +83,6 @@ BEGIN
     CREATE INDEX [IX_HoodContentCategoryJoins_CategoryId] ON [HoodContentCategoryJoins] ([CategoryId]);
 
     CREATE INDEX [IX_HoodContentMedia_ContentId] ON [HoodContentMedia] ([ContentId]);
+
+    CREATE INDEX [IX_HoodContent_AuthorId] ON [HoodContent] ([AuthorId]);
 END;

--- a/sql/07.00.00/20-context-hooddb.sql
+++ b/sql/07.00.00/20-context-hooddb.sql
@@ -9,7 +9,7 @@ BEGIN
         [Title] nvarchar(max) NULL,
         [Detail] nvarchar(max) NULL,
         [Type] int NOT NULL,
-        [UserId] nvarchar(max) NULL,
+        [UserId] nvarchar(450) NULL,
         [Source] nvarchar(max) NULL,
         [SourceUrl] nvarchar(max) NULL,
         CONSTRAINT [PK_HoodLogs] PRIMARY KEY ([Id])
@@ -56,4 +56,6 @@ BEGIN
     CREATE INDEX [IX_HoodMedia_DirectoryId] ON [HoodMedia] ([DirectoryId]);
 
     CREATE INDEX [IX_HoodMediaDirectories_ParentId] ON [HoodMediaDirectories] ([ParentId]);
+
+    CREATE INDEX [IX_HoodLogs_UserId] ON [HoodLogs] ([UserId]);
 END;

--- a/sql/07.00.00/30-context-identity.sql
+++ b/sql/07.00.00/30-context-identity.sql
@@ -8,6 +8,7 @@ BEGIN
         [Name] nvarchar(256) NULL,
         [NormalizedName] nvarchar(256) NULL,
         [ConcurrencyStamp] nvarchar(max) NULL,
+        [RemoteId] nvarchar(max) NULL,
         CONSTRAINT [PK_AspNetRoles] PRIMARY KEY ([Id])
     );
 

--- a/sql/07.00.00/40-context-property.sql
+++ b/sql/07.00.00/40-context-property.sql
@@ -60,7 +60,7 @@ BEGIN
         [QuickName] nvarchar(max) NULL,
         [Addressee] nvarchar(max) NULL,
         [Phone] nvarchar(max) NULL,
-        [AgentId] nvarchar(max) NULL,
+        [AgentId] nvarchar(450) NULL,
         [Floors] nvarchar(max) NULL,
         CONSTRAINT [PK_HoodProperties] PRIMARY KEY ([Id])
     );
@@ -121,4 +121,6 @@ BEGIN
     CREATE INDEX [IX_HoodPropertyFloorplans_PropertyId] ON [HoodPropertyFloorplans] ([PropertyId]);
 
     CREATE INDEX [IX_HoodPropertyMedia_PropertyId] ON [HoodPropertyMedia] ([PropertyId]);
+
+    CREATE INDEX [IX_HoodProperties_AgentId] ON [HoodProperties] ([AgentId]);
 END;

--- a/sql/07.00.00/50-update-from-6.1.sql
+++ b/sql/07.00.00/50-update-from-6.1.sql
@@ -6,10 +6,10 @@
 -- the 6.0/6.1 update scripts first — see sql/README.md for the chain).
 --
 -- The v7 changes are small: the legacy duplicate user tables are removed (AspNetUsers
--- is now the single authoritative user store), the unused Auth0 role-mapping column and
--- the legacy script-migration table are dropped, and the four reporting views are
--- rebuilt (the 6.1 definitions referenced columns that never existed on the base
--- tables and were silently broken). No data-bearing base-table columns are dropped.
+-- is now the single authoritative user store) and the legacy script-migration + EF
+-- migration-history tables are dropped. No data-bearing base-table columns are dropped.
+-- (AspNetRoles.RemoteId is intentionally KEPT — it's nullable on both auth backends so the
+-- schema is one shape; the Auth0 backend maps local roles to Auth0 platform roles via it.)
 -- =============================================================================
 
 SET QUOTED_IDENTIFIER ON;
@@ -27,15 +27,11 @@ IF OBJECT_ID('[ApplicationUser]', 'U') IS NOT NULL DROP TABLE [ApplicationUser];
 IF OBJECT_ID('[UserProfiles]', 'U')   IS NOT NULL DROP TABLE [UserProfiles];
 GO
 
--- 3. Drop AspNetRoles.RemoteId — removed from the v7 role model (standard IdentityRole).
-IF COL_LENGTH('AspNetRoles', 'RemoteId') IS NOT NULL ALTER TABLE [AspNetRoles] DROP COLUMN [RemoteId];
-GO
-
--- 4. Drop the legacy Hood script-migration table — unused in v7 (version tracked in HoodOptions).
+-- 3. Drop the legacy Hood script-migration table — unused in v7 (version tracked in HoodOptions).
 IF OBJECT_ID('[__HoodMigrationHistory]', 'U') IS NOT NULL DROP TABLE [__HoodMigrationHistory];
 GO
 
--- 5. Drop the EF Core migrations-history table. v7 applies schema via DbUp (journalled in
+-- 4. Drop the EF Core migrations-history table. v7 applies schema via DbUp (journalled in
 --    dbo.SchemaVersions) and never runs EF migrations at runtime, so a fresh v7 install has
 --    no such table — dropping it here makes an upgraded database converge with a fresh one.
 IF OBJECT_ID('[__EFMigrationsHistory]', 'U') IS NOT NULL DROP TABLE [__EFMigrationsHistory];
@@ -43,7 +39,7 @@ GO
 
 -- (Views are applied separately by the runner / the sql/7.0/views scripts — not rebuilt here.)
 
--- 6. Stamp the schema version.
+-- 5. Stamp the schema version.
 IF EXISTS (SELECT 1 FROM [HoodOptions] WHERE [Id] = 'Hood.Version')
     UPDATE [HoodOptions] SET [Value] = '7.0.0' WHERE [Id] = 'Hood.Version';
 ELSE

--- a/sql/07.00.00/60-converge.sql
+++ b/sql/07.00.00/60-converge.sql
@@ -1,0 +1,30 @@
+-- Apply key 07.00.00/60 | Hood v7.0.0 convergence delta (upgraded 6.x -> fresh 7.0 parity). Embedded; applied by hood-schema (DbUp) in LogicalName order.
+-- =============================================================================
+-- Hood CMS — v7.0 convergence delta
+-- =============================================================================
+-- Idempotent + forward-only. Runs AFTER the update deltas and BEFORE the reporting views,
+-- so the views rebuild over the converged column shapes. On a fresh install this is a no-op:
+-- the fresh DDL already produces the converged shape.
+--
+-- Brings residual upgrade-only drift on an upgraded 6.x database into line with a fresh v7
+-- install, so a schema compare is identical (within each auth backend).
+--
+-- AspNetUsers.Anonymous: 6.x carried it NOT NULL; a fresh v7 install models it nullable.
+-- Relax it so upgraded == fresh. Guarded on current nullability — re-runs are a no-op.
+--
+-- (The index + column-width drift converges via the fresh DDL itself: upgraded DBs already
+-- carry nvarchar(450) + the FK-era IX_ indexes, and the fresh DDL now creates the same — so
+-- there is nothing to alter here for those. AspNetRoles.RemoteId is kept on both backends.)
+
+SET QUOTED_IDENTIFIER ON;
+SET ANSI_NULLS ON;
+GO
+
+IF EXISTS (
+    SELECT 1 FROM sys.columns
+    WHERE object_id = OBJECT_ID(N'[AspNetUsers]', 'U')
+      AND name = 'Anonymous'
+      AND is_nullable = 0
+)
+    ALTER TABLE [AspNetUsers] ALTER COLUMN [Anonymous] bit NULL;
+GO

--- a/sql/README.md
+++ b/sql/README.md
@@ -61,13 +61,27 @@ Idempotent + forward-only structural cleanup that 6.1 applied:
 The v7 delta is small and **drops no data-bearing base-table columns**:
 
 - Removes the legacy duplicate user tables `ApplicationUser` and `UserProfiles` — `AspNetUsers` is now the single authoritative user store (nothing read or wrote the duplicates in 6.x).
-- Drops `AspNetRoles.RemoteId` (removed from the v7 role model).
-- Drops the unused `__HoodMigrationHistory` table (version is tracked in `HoodOptions`).
+- Drops the unused `__HoodMigrationHistory` and EF `__EFMigrationsHistory` tables (version is tracked in `HoodOptions`; the runner journals in `dbo.SchemaVersions`).
 - Stamps `HoodOptions['Hood.Version'] = '7.0.0'`.
+- `AspNetRoles.RemoteId` is **kept** — it's nullable on both auth backends so the schema is one shape (the Auth0 backend maps local roles to Auth0 platform roles via it; standard Identity leaves it null).
 
 (The reporting views are applied separately — the `*-view-*.sql` scripts, idempotent DROP/CREATE — so they're shared by fresh installs, upgrades and the runner.)
 
 Consumers on the 6.1.x baseline take a **clean, zero-data-loss** upgrade — verified that nothing reads any removed field.
+
+### What `07.00.00/60-converge.sql` does (upgrade → fresh parity)
+
+Idempotent convergence delta that runs after the update tier and before the views, so an **upgraded** 6.x database lands on the *same* schema as a **fresh** install. On a fresh install it's a no-op.
+
+- Relaxes `AspNetUsers.Anonymous` to nullable (6.x carried it `NOT NULL`; a fresh v7 install models it nullable).
+
+(The other historical drift converges via the fresh DDL itself — fresh installs now create the `AuthorId` / `UserId` / `AgentId` columns as `nvarchar(450)` **+ indexed**, the shape upgraded DBs already carry, and keep `AspNetRoles.RemoteId`. So there's nothing for the converge delta to alter for those.)
+
+## Convergence invariant & the parity guard
+
+Hood commits to **`fresh == upgrade`** — a database upgraded through the script chain is byte-for-byte identical to a fresh install, **within each auth backend**. Standard Identity and the Auth0 backend are *intentionally* different shapes (Auth0 omits the local-credential surface — password/security columns, the claims/logins/tokens tables — and adds `AspNetAuth0Identities`); that divergence is by design, not drift.
+
+`projects/Hood.Tests/SchemaParityTests.cs` enforces it: it provisions a fresh database via the runner and asserts the converged shape (bounded + indexed user-reference columns, a nullable `AspNetRoles.RemoteId`, a nullable `AspNetUsers.Anonymous`), plus that the converge delta relaxes `Anonymous` and is idempotent. It's `SkippableFact`-gated — runs in CI (where a SQL Server is provisioned), skips locally without one.
 
 ## Regenerating the SQL after a model change
 
@@ -100,7 +114,7 @@ sql/
     35-context-auth0.sql               # ALTERNATIVE Auth0 backend — NOT embedded; consumer applies instead of Identity
     40-context-property.sql
     50-update-from-6.1.sql             # 6.1.x -> 7.0 upgrade delta
-    60-…                               # (reserved) convergence delta — HOOD-104
+    60-converge.sql                    # convergence delta (upgraded 6.x -> fresh parity)
     70-view-contentviews.sql           # reporting views (idempotent DROP/CREATE)
     80-view-propertyviews.sql
     90-view-userprofiles.sql

--- a/sql/latest.sql
+++ b/sql/latest.sql
@@ -22,6 +22,7 @@ BEGIN
         [Name] nvarchar(256) NULL,
         [NormalizedName] nvarchar(256) NULL,
         [ConcurrencyStamp] nvarchar(max) NULL,
+        [RemoteId] nvarchar(max) NULL,
         CONSTRAINT [PK_AspNetRoles] PRIMARY KEY ([Id])
     );
 
@@ -126,7 +127,7 @@ BEGIN
         [Title] nvarchar(max) NULL,
         [Detail] nvarchar(max) NULL,
         [Type] int NOT NULL,
-        [UserId] nvarchar(max) NULL,
+        [UserId] nvarchar(450) NULL,
         [Source] nvarchar(max) NULL,
         [SourceUrl] nvarchar(max) NULL,
         CONSTRAINT [PK_HoodLogs] PRIMARY KEY ([Id])
@@ -173,6 +174,8 @@ BEGIN
     CREATE INDEX [IX_HoodMedia_DirectoryId] ON [HoodMedia] ([DirectoryId]);
 
     CREATE INDEX [IX_HoodMediaDirectories_ParentId] ON [HoodMediaDirectories] ([ParentId]);
+
+    CREATE INDEX [IX_HoodLogs_UserId] ON [HoodLogs] ([UserId]);
 END;
 
 -- Content tables — idempotent: the whole block runs only on a database that doesn't
@@ -198,7 +201,7 @@ BEGIN
         [AllowComments] bit NOT NULL,
         [Public] bit NOT NULL,
         [Featured] bit NOT NULL,
-        [AuthorId] nvarchar(max) NULL,
+        [AuthorId] nvarchar(450) NULL,
         [FeaturedImageJson] nvarchar(max) NULL,
         [ShareImageJson] nvarchar(max) NULL,
         CONSTRAINT [PK_HoodContent] PRIMARY KEY ([Id])
@@ -259,6 +262,8 @@ BEGIN
     CREATE INDEX [IX_HoodContentCategoryJoins_CategoryId] ON [HoodContentCategoryJoins] ([CategoryId]);
 
     CREATE INDEX [IX_HoodContentMedia_ContentId] ON [HoodContentMedia] ([ContentId]);
+
+    CREATE INDEX [IX_HoodContent_AuthorId] ON [HoodContent] ([AuthorId]);
 END;
 
 -- Property tables — idempotent: the whole block runs only on a database that doesn't
@@ -322,7 +327,7 @@ BEGIN
         [QuickName] nvarchar(max) NULL,
         [Addressee] nvarchar(max) NULL,
         [Phone] nvarchar(max) NULL,
-        [AgentId] nvarchar(max) NULL,
+        [AgentId] nvarchar(450) NULL,
         [Floors] nvarchar(max) NULL,
         CONSTRAINT [PK_HoodProperties] PRIMARY KEY ([Id])
     );
@@ -383,6 +388,8 @@ BEGIN
     CREATE INDEX [IX_HoodPropertyFloorplans_PropertyId] ON [HoodPropertyFloorplans] ([PropertyId]);
 
     CREATE INDEX [IX_HoodPropertyMedia_PropertyId] ON [HoodPropertyMedia] ([PropertyId]);
+
+    CREATE INDEX [IX_HoodProperties_AgentId] ON [HoodProperties] ([AgentId]);
 END;
 
 -- ===========================================================================


### PR DESCRIPTION
## Overview

A database upgraded through the script chain didn't end up byte-for-byte identical to a fresh install. This converges the two — fresh `==` upgrade, *within each auth backend* — and adds a regression test so the drift can't silently return.

Closes HOOD-104.

---

## What Changed and Why

**Fresh DDL now matches the upgraded shape.** `HoodContent.AuthorId`, `HoodLogs.UserId`, `HoodProperties.AgentId` are modelled as `nvarchar(450)` **+ indexed** (they were `nvarchar(max)`, unindexed). Upgraded 6.x databases already carry this shape from the FK era, so converging *to* it means **zero migration on existing data** — only fresh installs change. Model config + regenerated baselines + `sql/` scripts.

**`AspNetRoles.RemoteId` is universal nullable.** Added as a shadow property on the standard role (no CLR member — the standard backend never reads it) and the update delta **no longer drops it**, so `AspNetRoles` is one shape across both auth backends. The Auth0 backend still maps local roles to platform roles via it.

**New convergence delta** `07.00.00/60-converge.sql` relaxes `AspNetUsers.Anonymous` to nullable on upgraded databases (a fresh install already models it nullable). Idempotent; a no-op on fresh installs.

**Convergence is enforced, not hoped for.** `SchemaParityTests` provisions a fresh database via the runner and asserts the converged shape (bounded + indexed user-ref columns, nullable `RemoteId`, nullable `Anonymous`), plus that the converge delta relaxes `Anonymous` and is idempotent. The pins go **red on the pre-convergence schema and green after**, so a regression fails CI. `SkippableFact`-gated (runs where a SQL Server is provisioned, skips otherwise).

**Backends are intentionally different** — Auth0 omits the local-credential surface (password/security columns, claims/logins/tokens) and adds `AspNetAuth0Identities`. Parity is asserted *within* each backend, not across them.

---

## Tests

- `SchemaParityTests` (4 new facts): converged-shape pins, converge-delta effect + idempotency, runner re-run no-op.
- Full suite green against a freshly-provisioned database (41 passed), including the reporting views over the changed columns.
- `validate_code.sh` clean (CSharpier + InspectCode, no issues).
- Verified end-to-end against fresh installs and upgraded databases (incl. a ~24.5k-user upgraded pull) — convergence applies with zero data loss.

---

## Breaking Changes

⚠️ **Pre-GA baseline regeneration.** The EF baseline was *regenerated* (not an incremental migration) — Hood doesn't stack mid-version migrations before a release. Fresh `7.0.0` installs now produce the converged shape. Anyone running a `7.0.0` release candidate re-baselines on the way to GA (RC-in-prod accepts data loss, per the release convention). Not a change to any shipped release.

---

## Testing Plan

- [ ] `hood-schema upgrade` on a fresh database → converged shape (`nvarchar(450)` + indexes, `RemoteId` present, `Anonymous` nullable).
- [ ] `hood-schema upgrade` on an upgraded 6.x database → `Anonymous` relaxed, data intact.
- [ ] Re-run → clean no-op.