### PR TITLE
HOOD-80, HOOD-111, HOOD-110, HOOD-72: v7 backlog bug sweep

### DIFF
--- a/projects/Hood.Core/Hood.Core.csproj
+++ b/projects/Hood.Core/Hood.Core.csproj
@@ -53,16 +53,18 @@
     <PackageReference Include="unsplasharp.api" Version="0.7.0" />
   </ItemGroup>
   <!-- The repo-root sql tier scripts are embedded so the Hood.Core NuGet carries its own schema.
-       One glob; DbUp applies them in LogicalName order. Scripts live in zero-padded version folders
-       (MM.mm.pp) with a gapped numeric sequence per file (SS-<name>.sql, e.g.
-       07.00.00/50-update-from-6.1.sql) so apply order is explicit and never relies on alphabetical
-       accidents. Every component is padded so it sorts ordinally (07 before a future 10). Excluded:
-       latest.sql (the assembled fresh-install convenience file) and the Auth0 backend scripts (the
-       alternative backend, applied by the consumer, not the standard-Identity runner path). -->
+       One glob; DbUp applies them in ordinal LogicalName order. Scripts live in zero-padded version
+       folders (MM.mm.pp). Within a folder the prefix encodes a phase: structural snapshots use a low
+       fixed band (00-0x context DDL, regenerated), forward deltas + data-migrations use a yyyyMMddHHmm
+       timestamp (append-only, collision-free across branches, mirrors the authoring EF migration), and
+       reporting views use a high band (9x, regenerated). Ordinal sort gives 0x < 2026... < 9x, so the
+       bands bookend the timestamped middle. Excluded: latest.sql (the assembled fresh-install
+       convenience file) and the Auth0 backend scripts (the alternative backend, applied by the
+       consumer, not the standard-Identity runner path). -->
   <ItemGroup>
     <EmbeddedResource
       Include="$(MSBuildThisFileDirectory)../../sql/**/*.sql"
-      Exclude="$(MSBuildThisFileDirectory)../../sql/latest.sql;$(MSBuildThisFileDirectory)../../sql/07.00.00/35-context-auth0.sql;$(MSBuildThisFileDirectory)../../sql/07.00.00/95-view-auth0userprofiles.sql"
+      Exclude="$(MSBuildThisFileDirectory)../../sql/latest.sql;$(MSBuildThisFileDirectory)../../sql/07.00.00/03-context-auth0.sql;$(MSBuildThisFileDirectory)../../sql/07.00.00/93-view-auth0userprofiles.sql"
     >
       <LogicalName>Hood.Core.SchemaScripts.%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
     </EmbeddedResource>

--- a/projects/Hood.Core/Models/Media/MediaObject.cs
+++ b/projects/Hood.Core/Models/Media/MediaObject.cs
@@ -65,9 +65,9 @@ namespace Hood.Models
         )
         {
             ThumbUrl = thumbUrl.IsSet() ? thumbUrl : url;
-            SmallUrl = smallUrl.IsSet() ? thumbUrl : url;
-            MediumUrl = mediumUrl.IsSet() ? thumbUrl : url;
-            LargeUrl = largeUrl.IsSet() ? thumbUrl : url;
+            SmallUrl = smallUrl.IsSet() ? smallUrl : url;
+            MediumUrl = mediumUrl.IsSet() ? mediumUrl : url;
+            LargeUrl = largeUrl.IsSet() ? largeUrl : url;
             Url = url;
         }
 

--- a/projects/Hood.Core/Models/Settings/IntegrationSettings.cs
+++ b/projects/Hood.Core/Models/Settings/IntegrationSettings.cs
@@ -17,20 +17,23 @@ namespace Hood.Models
         [Display(Name = "Enable Google Maps")]
         public bool EnableGoogleMaps { get; set; }
 
-        [Display(Name = "Google API Key")]
-        public string GoogleMapsApiKey { get; set; }
+        [Display(
+            Name = "Google Cloud API Key",
+            Description = "A single Google Cloud API key used for Maps, Geocoding and reCAPTCHA Enterprise. Enable the Maps JavaScript, Geocoding and reCAPTCHA Enterprise APIs on it. It is rendered in the browser for maps, so referrer restrictions cannot be used (reCAPTCHA Enterprise also requires no referrer restriction) — restrict by API instead."
+        )]
+        public string GoogleCloudApiKey { get; set; }
 
         // Computed read-only flags — derived from the stored settings, never persisted.
         [JsonIgnore]
         public bool IsGoogleMapsEnabled
         {
-            get { return GoogleMapsApiKey.IsSet() && EnableGoogleMaps; }
+            get { return GoogleCloudApiKey.IsSet() && EnableGoogleMaps; }
         }
 
         [JsonIgnore]
         public bool IsGoogleGeocodingEnabled
         {
-            get { return GoogleMapsApiKey.IsSet() && EnableGoogleGeocoding; }
+            get { return GoogleCloudApiKey.IsSet() && EnableGoogleGeocoding; }
         }
 
         [JsonIgnore]
@@ -40,7 +43,7 @@ namespace Hood.Models
             {
                 return GoogleRecaptchaSiteKey.IsSet()
                     && GoogleRecaptchaProjectId.IsSet()
-                    && GoogleRecaptchaApiKey.IsSet()
+                    && GoogleCloudApiKey.IsSet()
                     && EnableGoogleRecaptcha;
             }
         }
@@ -64,12 +67,6 @@ namespace Hood.Models
             Description = "The Google Cloud project that owns the key (from the console project picker, e.g. my-project-123456) — not the key ID."
         )]
         public string GoogleRecaptchaProjectId { get; set; }
-
-        [Display(
-            Name = "Google Cloud API Key",
-            Description = "A Google Cloud API key (APIs & Services > Credentials) with the reCAPTCHA Enterprise API enabled and no HTTP-referrer restriction. Not the legacy secret key."
-        )]
-        public string GoogleRecaptchaApiKey { get; set; }
 
         [Display(
             Name = "Google Recaptcha Security Threshold",

--- a/projects/Hood.Core/Services/AddressService/AddressService.cs
+++ b/projects/Hood.Core/Services/AddressService/AddressService.cs
@@ -60,7 +60,12 @@ namespace Hood.Services
                         .GetAwaiter()
                         .GetResult();
                 }
-                catch { }
+                catch (Exception logEx)
+                {
+                    System.Diagnostics.Debug.WriteLine(
+                        $"AddressService: failed to log a geocoding error: {logEx.Message}"
+                    );
+                }
 
                 return null;
             }

--- a/projects/Hood.Core/Services/AddressService/AddressService.cs
+++ b/projects/Hood.Core/Services/AddressService/AddressService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Geocoding;
@@ -16,28 +17,53 @@ namespace Hood.Services
             if (!key.IsSet() || !Engine.Settings.Integrations.EnableGoogleGeocoding)
                 return null;
 
-            IGeocoder geocoder = new GoogleGeocoder() { ApiKey = key };
-            // Materialise the geocoder results — re-enumerating a lazy result here could
-            // re-issue the HTTP geocode request.
-            List<Address> addresses = geocoder
-                .GeocodeAsync(
-                    address.Number.IsSet()
-                        ? string.Format("{0} {1}", address.Number, address.Address1)
-                        : address.Address1,
-                    address.City,
-                    address.County,
-                    address.Postcode,
-                    address.Country
-                )
-                .Result.ToList();
-            if (addresses.Count == 0)
+            // Geocoding must never surface as a 500 — an invalid/denied key, an over-quota
+            // account or a transient HTTP failure all throw out of GoogleGeocoder (and the
+            // blocking .Result rethrows them wrapped in an AggregateException, which is why
+            // catching GoogleGeocodingException at the call sites was insufficient). Swallow
+            // everything here, log it, and return null so callers fall back gracefully.
+            try
             {
-                addresses = geocoder.GeocodeAsync(address.Postcode).Result.ToList();
+                IGeocoder geocoder = new GoogleGeocoder() { ApiKey = key };
+                // Materialise the geocoder results — re-enumerating a lazy result here could
+                // re-issue the HTTP geocode request.
+                List<Address> addresses = geocoder
+                    .GeocodeAsync(
+                        address.Number.IsSet()
+                            ? string.Format("{0} {1}", address.Number, address.Address1)
+                            : address.Address1,
+                        address.City,
+                        address.County,
+                        address.Postcode,
+                        address.Country
+                    )
+                    .Result.ToList();
                 if (addresses.Count == 0)
-                    return null;
-            }
+                {
+                    addresses = geocoder.GeocodeAsync(address.Postcode).Result.ToList();
+                    if (addresses.Count == 0)
+                        return null;
+                }
 
-            return (GoogleAddress)addresses.First();
+                return (GoogleAddress)addresses.First();
+            }
+            catch (Exception ex)
+            {
+                // Best-effort log; never let a logging failure mask the silent geocode fallback.
+                try
+                {
+                    Engine
+                        .Logs.AddExceptionAsync<AddressService>(
+                            "Geocoding failed — check the Google Cloud API key has the Geocoding API enabled and is within quota. Returning no location.",
+                            ex
+                        )
+                        .GetAwaiter()
+                        .GetResult();
+                }
+                catch { }
+
+                return null;
+            }
         }
     }
 }

--- a/projects/Hood.Core/Services/AddressService/AddressService.cs
+++ b/projects/Hood.Core/Services/AddressService/AddressService.cs
@@ -13,7 +13,7 @@ namespace Hood.Services
     {
         public GoogleAddress GeocodeAddress(IAddress address)
         {
-            var key = Engine.Settings.Integrations.GoogleMapsApiKey;
+            var key = Engine.Settings.Integrations.GoogleCloudApiKey;
             if (!key.IsSet() || !Engine.Settings.Integrations.EnableGoogleGeocoding)
                 return null;
 

--- a/projects/Hood.Core/Services/PropertyImporter/BlmFileImporter.cs
+++ b/projects/Hood.Core/Services/PropertyImporter/BlmFileImporter.cs
@@ -1281,7 +1281,10 @@ namespace Hood.Services
                 try
                 {
                     GoogleAddress loc = _address.GeocodeAddress(property);
-                    property.SetLocation(loc.Coordinates);
+                    if (loc != null)
+                    {
+                        property.SetLocation(loc.Coordinates);
+                    }
                 }
                 catch (GoogleGeocodingException ex)
                 {

--- a/projects/Hood.Core/Services/RecaptchaService/RecaptchaService.cs
+++ b/projects/Hood.Core/Services/RecaptchaService/RecaptchaService.cs
@@ -69,7 +69,7 @@ namespace Hood.Services
                 string token = request.Form["g-recaptcha-response"];
                 Assessment assessment = await _assessmentClient.CreateAssessmentAsync(
                     settings.GoogleRecaptchaProjectId,
-                    settings.GoogleRecaptchaApiKey,
+                    settings.GoogleCloudApiKey,
                     new Event
                     {
                         Token = token ?? string.Empty,

--- a/projects/Hood.Core/TagHelpers/RecaptchaTagHelper.cs
+++ b/projects/Hood.Core/TagHelpers/RecaptchaTagHelper.cs
@@ -32,7 +32,10 @@ namespace Hood.TagHelpers
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            if (!Engine.Settings.Integrations.EnableGoogleRecaptcha)
+            // Integrations is null when the IntegrationSettings option row doesn't exist yet (a site
+            // whose settings have never been saved / a partially-installed database). Treat that — and
+            // the recaptcha-disabled case — identically: render nothing rather than NRE the page.
+            if (Engine.Settings?.Integrations?.EnableGoogleRecaptcha != true)
                 return;
 
             output.TagName = "div";

--- a/projects/Hood.Tests/Hood.Tests.csproj
+++ b/projects/Hood.Tests/Hood.Tests.csproj
@@ -7,11 +7,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Hood.Core\Hood.Core.csproj" />
+    <!-- The web host (SUT) for the WebApplicationFactory HTTP smoke tests (HOOD-72). -->
+    <ProjectReference Include="..\Hood.Development\Hood.Development.csproj" />
   </ItemGroup>
 </Project>

--- a/projects/Hood.Tests/HttpSmokeTests.cs
+++ b/projects/Hood.Tests/HttpSmokeTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
@@ -222,7 +221,7 @@ namespace Hood.Tests
     /// post-build Hood bootstrap (LoadHoodAsync) that Program.Main runs — without altering production
     /// startup.
     /// </summary>
-    public class HoodWebApplicationFactory : WebApplicationFactory<Hood.Web.Program>
+    public class HoodWebApplicationFactory : WebApplicationFactory<Web.Program>
     {
         private readonly string _connectionString;
 

--- a/projects/Hood.Tests/HttpSmokeTests.cs
+++ b/projects/Hood.Tests/HttpSmokeTests.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Hood.Contexts;
+using Hood.Models;
+using Hood.Startup;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Hood.Tests
+{
+    /// <summary>
+    /// Boots the real Hood web app in-process via <see cref="WebApplicationFactory{TEntryPoint}"/>
+    /// against the test SQL database and drives HTTP smoke checks (HOOD-72): the anonymous login page
+    /// renders, and after a genuine cookie login the standard-Identity admin pages (the HOOD-66 role
+    /// views included) render without 500s.
+    ///
+    /// Engine initialisation already happens inside the host pipeline (ConfigureHood / UseHood), which
+    /// WebApplicationFactory runs — so the WAF-hosted app behaves like the real one. The only piece
+    /// Program.Main adds after Build() is the LoadHoodAsync() DB-readiness probe; the factory below
+    /// invokes that same step against the test host, so production startup is left untouched.
+    ///
+    /// SkippableFact-gated on the shared <see cref="DatabaseFixture"/>: runs in CI (DB provisioned),
+    /// skips cleanly on a machine without one. Auth0 is a separate backend and is not exercised here.
+    /// </summary>
+    public class HttpSmokeTests : IClassFixture<HttpSmokeFixture>
+    {
+        private readonly HttpSmokeFixture _fx;
+
+        public HttpSmokeTests(HttpSmokeFixture fx) => _fx = fx;
+
+        // Secure cookies (SecurePolicy.Always) mean the auth + antiforgery cookies are only issued over
+        // HTTPS, so the test client must speak https. No auto-redirect: we assert the login POST's 302
+        // (success) vs a 200 form re-render (failure) directly, and check admin pages aren't bounced to login.
+        private HttpClient NewClient() =>
+            _fx.Factory.CreateClient(
+                new WebApplicationFactoryClientOptions
+                {
+                    BaseAddress = new Uri("https://localhost"),
+                    AllowAutoRedirect = false,
+                    HandleCookies = true,
+                }
+            );
+
+        [SkippableFact]
+        public async Task Anonymous_login_page_renders_200()
+        {
+            Skip.IfNot(_fx.Db.Available, _fx.Db.UnavailableReason);
+
+            using var client = NewClient();
+            var resp = await client.GetAsync("/account/login");
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+
+        [SkippableFact]
+        public async Task Authenticated_admin_pages_render_without_500()
+        {
+            Skip.IfNot(_fx.Db.Available, _fx.Db.UnavailableReason);
+
+            using var client = NewClient();
+
+            // GET the login page; the antiforgery cookie is captured by the client's cookie handler.
+            var loginGet = await client.GetAsync("/account/login");
+            loginGet.EnsureSuccessStatusCode();
+
+            // Replay every hidden field the form rendered — the antiforgery token plus the anti-spam
+            // fields (ts/hsh/slt) that LoginViewModel's SpamPreventionModel validation requires — then
+            // add the credentials. (The honeypot is a CSS-hidden text input, not type=hidden, so it's
+            // correctly left empty.)
+            var fields = ExtractHiddenFields(await loginGet.Content.ReadAsStringAsync());
+            Skip.IfNot(
+                fields.ContainsKey("__RequestVerificationToken"),
+                "Antiforgery token not found on the login page."
+            );
+            fields["Username"] = HttpSmokeFixture.AdminEmail;
+            fields["Password"] = HttpSmokeFixture.AdminPassword;
+            fields["RememberMe"] = "false";
+
+            var loginPost = await client.PostAsync(
+                "/account/login",
+                new FormUrlEncodedContent(fields)
+            );
+
+            // Success redirects (302) to a local page; a 200 means the form re-rendered = login failed.
+            Assert.True(
+                loginPost.StatusCode == HttpStatusCode.Redirect
+                    || loginPost.StatusCode == HttpStatusCode.Found,
+                $"Login POST expected a 302 redirect on success but got {(int)loginPost.StatusCode} {loginPost.StatusCode}."
+            );
+
+            // The authenticated admin surfaces must render — no 500, and not bounced (302) back to login.
+            foreach (
+                var path in new[] { "/admin/users/", "/admin/roles/", "/admin/content/manage/" }
+            )
+            {
+                var resp = await client.GetAsync(path);
+                Assert.True(
+                    resp.StatusCode == HttpStatusCode.OK,
+                    $"GET {path} expected 200 but got {(int)resp.StatusCode} {resp.StatusCode}."
+                );
+            }
+        }
+
+        // Pulls every <input type=hidden> name/value pair out of the rendered page. Handles both
+        // single- and double-quoted attributes — the framework antiforgery token uses double quotes,
+        // but Hood's honeypot/anti-spam fields (ts/hsh/slt) are rendered single-quoted.
+        private static Dictionary<string, string> ExtractHiddenFields(string html)
+        {
+            var fields = new Dictionary<string, string>();
+            foreach (Match tag in Regex.Matches(html, "<input\\b[^>]*>"))
+            {
+                if (!Regex.IsMatch(tag.Value, "type=[\"']hidden[\"']"))
+                    continue;
+                var name = Regex.Match(tag.Value, "name=[\"']([^\"']+)[\"']");
+                if (!name.Success)
+                    continue;
+                var value = Regex.Match(tag.Value, "value=[\"']([^\"']*)[\"']");
+                fields[name.Groups[1].Value] = value.Success ? value.Groups[1].Value : "";
+            }
+            return fields;
+        }
+    }
+
+    /// <summary>
+    /// Owns the in-process web host and seeds a standard-Identity admin user (with the Admin role) once
+    /// per test class. No-ops when the database is unavailable so the tests skip rather than fail.
+    /// </summary>
+    public class HttpSmokeFixture : IAsyncLifetime
+    {
+        public const string AdminEmail = "smoke-admin@hood.test";
+        public const string AdminPassword = "Smoke!admin123";
+
+        public DatabaseFixture Db { get; } = new DatabaseFixture();
+        public HoodWebApplicationFactory Factory { get; private set; }
+
+        public async Task InitializeAsync()
+        {
+            if (!Db.Available)
+                return;
+
+            Factory = new HoodWebApplicationFactory(Db.ConnectionString);
+
+            // Resolving Services forces the host to build (and runs LoadHoodAsync via the factory).
+            using var scope = Factory.Services.CreateScope();
+            var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+            var userManager = scope.ServiceProvider.GetRequiredService<
+                UserManager<ApplicationUser>
+            >();
+
+            foreach (var role in new[] { "SuperUser", "Admin" })
+            {
+                if (!await roleManager.RoleExistsAsync(role))
+                    await roleManager.CreateAsync(new IdentityRole(role));
+            }
+
+            var user = await userManager.FindByNameAsync(AdminEmail);
+            if (user == null)
+            {
+                // ApplicationUser and UserProfile table-split the AspNetUsers row sharing a PK, so the
+                // profile must be seeded inline with the same Id (mirrors InstallController) — otherwise
+                // the row is malformed and the cookie OnValidatePrincipal hook 500s every admin request.
+                var id = Guid.NewGuid().ToString();
+                user = new ApplicationUser
+                {
+                    Id = id,
+                    UserName = AdminEmail,
+                    Email = AdminEmail,
+                    EmailConfirmed = true,
+                    Active = true,
+                    CreatedOn = DateTime.UtcNow,
+                    LastLogOn = DateTime.UtcNow,
+                    LastLoginIP = "127.0.0.1",
+                    LastLoginLocation = "Test",
+                    UserProfile = new UserProfile
+                    {
+                        Id = id,
+                        Email = AdminEmail,
+                        UserName = AdminEmail,
+                        FirstName = "Smoke",
+                        LastName = "Admin",
+                        JobTitle = "Website Administrator",
+                        Anonymous = false,
+                    },
+                };
+                await userManager.CreateAsync(user, AdminPassword);
+            }
+
+            if (!await userManager.IsInRoleAsync(user, "Admin"))
+                await userManager.AddToRoleAsync(user, "Admin");
+
+            // Run the same install seed production uses: it writes the Hood.Settings.SiteOwner option
+            // (which the [Installed] filter gates on, otherwise every page 302s to the install wizard)
+            // and seeds the default settings/media directories. Without the seeded IntegrationSettings,
+            // the recaptcha tag helper on the login page NREs. GetSiteAdmin reuses our admin because
+            // Hood:SuperAdminEmail is pointed at it above. Seed is idempotent, so it's safe to run every
+            // time (and repairs a half-installed database, not just a pristine one).
+            var hoodDb = scope.ServiceProvider.GetRequiredService<HoodDbContext>();
+            var identityContext = scope.ServiceProvider.GetRequiredService<IdentityContext>();
+            await hoodDb.Seed(identityContext);
+        }
+
+        public Task DisposeAsync()
+        {
+            Factory?.Dispose();
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// WebApplicationFactory that points the host at the test database and invokes the same
+    /// post-build Hood bootstrap (LoadHoodAsync) that Program.Main runs — without altering production
+    /// startup.
+    /// </summary>
+    public class HoodWebApplicationFactory : WebApplicationFactory<Hood.Web.Program>
+    {
+        private readonly string _connectionString;
+
+        public HoodWebApplicationFactory(string connectionString) =>
+            _connectionString = connectionString;
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureAppConfiguration(
+                (_, config) =>
+                    config.AddInMemoryCollection(
+                        new Dictionary<string, string>
+                        {
+                            ["ConnectionStrings:DefaultConnection"] = _connectionString,
+                            // The install seed resolves the site owner via Hood:SuperAdminEmail; point it
+                            // at the seeded admin so Seed() reuses that user rather than creating a stray one.
+                            ["Hood:SuperAdminEmail"] = HttpSmokeFixture.AdminEmail,
+                        }
+                    )
+            );
+            // TestServer leaves Connection.RemoteIpAddress null, but the login action stamps
+            // RemoteIpAddress.ToString() onto the user — which would NRE. Real Kestrel always sets it;
+            // give the test host a loopback address so the production code path runs unchanged.
+            builder.ConfigureServices(services =>
+                services.AddSingleton<IStartupFilter, LoopbackRemoteIpStartupFilter>()
+            );
+        }
+
+        private sealed class LoopbackRemoteIpStartupFilter : IStartupFilter
+        {
+            public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) =>
+                app =>
+                {
+                    app.Use(
+                        async (ctx, nextMiddleware) =>
+                        {
+                            ctx.Connection.RemoteIpAddress ??= IPAddress.Loopback;
+                            ctx.Connection.LocalIpAddress ??= IPAddress.Loopback;
+                            await nextMiddleware();
+                        }
+                    );
+                    next(app);
+                };
+        }
+
+        protected override IHost CreateHost(IHostBuilder builder)
+        {
+            var host = base.CreateHost(builder);
+            host.LoadHoodAsync().GetAwaiter().GetResult();
+            return host;
+        }
+    }
+}

--- a/projects/Hood.Tests/MediaObjectTests.cs
+++ b/projects/Hood.Tests/MediaObjectTests.cs
@@ -1,0 +1,57 @@
+using Hood.Models;
+using Xunit;
+
+namespace Hood.Tests
+{
+    /// <summary>
+    /// Pure unit tests for the <see cref="MediaBase"/> convenience constructor's URL fallback
+    /// logic (HOOD-80). No database — exercises the ctor in isolation.
+    /// </summary>
+    public class MediaObjectTests
+    {
+        [Fact]
+        public void Ctor_with_only_url_falls_all_sizes_back_to_url()
+        {
+            var media = new MediaObject("https://cdn/full.jpg");
+
+            Assert.Equal("https://cdn/full.jpg", media.Url);
+            Assert.Equal("https://cdn/full.jpg", media.ThumbUrl);
+            Assert.Equal("https://cdn/full.jpg", media.SmallUrl);
+            Assert.Equal("https://cdn/full.jpg", media.MediumUrl);
+            Assert.Equal("https://cdn/full.jpg", media.LargeUrl);
+        }
+
+        [Fact]
+        public void Ctor_assigns_each_size_url_to_its_own_field()
+        {
+            var media = new MediaObject(
+                url: "https://cdn/full.jpg",
+                smallUrl: "https://cdn/small.jpg",
+                mediumUrl: "https://cdn/medium.jpg",
+                largeUrl: "https://cdn/large.jpg",
+                thumbUrl: "https://cdn/thumb.jpg"
+            );
+
+            Assert.Equal("https://cdn/full.jpg", media.Url);
+            Assert.Equal("https://cdn/thumb.jpg", media.ThumbUrl);
+            Assert.Equal("https://cdn/small.jpg", media.SmallUrl);
+            Assert.Equal("https://cdn/medium.jpg", media.MediumUrl);
+            Assert.Equal("https://cdn/large.jpg", media.LargeUrl);
+        }
+
+        [Fact]
+        public void Ctor_falls_back_per_field_when_only_some_sizes_set()
+        {
+            // Only medium supplied — small/large/thumb fall back to url, medium keeps its own.
+            var media = new MediaObject(
+                url: "https://cdn/full.jpg",
+                mediumUrl: "https://cdn/medium.jpg"
+            );
+
+            Assert.Equal("https://cdn/medium.jpg", media.MediumUrl);
+            Assert.Equal("https://cdn/full.jpg", media.SmallUrl);
+            Assert.Equal("https://cdn/full.jpg", media.LargeUrl);
+            Assert.Equal("https://cdn/full.jpg", media.ThumbUrl);
+        }
+    }
+}

--- a/projects/Hood.Tests/RecaptchaServiceTests.cs
+++ b/projects/Hood.Tests/RecaptchaServiceTests.cs
@@ -54,7 +54,7 @@ namespace Hood.Tests
                 EnableGoogleRecaptcha = true,
                 GoogleRecaptchaSiteKey = "site-key",
                 GoogleRecaptchaProjectId = "my-project",
-                GoogleRecaptchaApiKey = "api-key",
+                GoogleCloudApiKey = "api-key",
                 GoogleRecaptchaThreshold = threshold,
             };
         }

--- a/projects/Hood.Tests/SchemaParityTests.cs
+++ b/projects/Hood.Tests/SchemaParityTests.cs
@@ -203,7 +203,9 @@ namespace Hood.Tests
                     )
                 );
 
-                var converge = ReadEmbedded("Hood.Core.SchemaScripts.07.00.00/60-converge.sql");
+                var converge = ReadEmbedded(
+                    "Hood.Core.SchemaScripts.07.00.00/202606131526-converge.sql"
+                );
                 Exec(db, converge);
                 Assert.Equal(
                     "YES",

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Info.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Info.cshtml
@@ -24,7 +24,7 @@
     <partial name="_Editor_Images" />
     <h5 class="mt-4 mb-0">Property Address</h5>
     <p>Address and location information for this property listing.</p>
-    @if (_integrationSettings.EnableGoogleGeocoding && _integrationSettings.GoogleMapsApiKey.IsSet())
+    @if (_integrationSettings.EnableGoogleGeocoding && _integrationSettings.GoogleCloudApiKey.IsSet())
     {
         <div class="form-floating mb-3">
             <label for="address-autocomplete">Search for an address (Google Lookup)</label>

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Settings/Integrations.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Settings/Integrations.cshtml
@@ -42,9 +42,9 @@
                     </div>
                 </div>
                 <div class="form-floating mb-3">
-                    <input asp-for="GoogleMapsApiKey" class="form-control">
-                    <label asp-for="GoogleMapsApiKey"></label>
-                    <small asp-for="GoogleMapsApiKey"></small>
+                    <input asp-for="GoogleCloudApiKey" class="form-control">
+                    <label asp-for="GoogleCloudApiKey"></label>
+                    <small asp-for="GoogleCloudApiKey"></small>
                 </div>
                 <hr class="mt-4 mb-4" />
                 <div class="mb-3">
@@ -64,10 +64,8 @@
                     <label asp-for="GoogleRecaptchaProjectId"></label>
                     <small asp-for="GoogleRecaptchaProjectId"></small>
                 </div>
-                <div class="form-floating mb-3">
-                    <input asp-for="GoogleRecaptchaApiKey" class="form-control">
-                    <label asp-for="GoogleRecaptchaApiKey"></label>
-                    <small asp-for="GoogleRecaptchaApiKey"></small>
+                <div class="alert alert-info" role="alert">
+                    reCAPTCHA Enterprise authenticates with the shared <strong>Google Cloud API Key</strong> set above — enable the reCAPTCHA Enterprise API on that key.
                 </div>
                 <div class="form-floating">
                     <select asp-for="GoogleRecaptchaThreshold" class="form-select">

--- a/projects/Hood.UI.Bootstrap3/UI/Shared/_Scripts_Google.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Shared/_Scripts_Google.cshtml
@@ -2,7 +2,7 @@
     IntegrationSettings _plugins = Engine.Settings.Integrations;
 }
 <script src="https://cdn.jsdelivr.net/npm/hoodcms@4.1.6/js/app/google.min.js"></script>
-@if (_plugins.GoogleMapsApiKey.IsSet() && (_plugins.EnableGoogleMaps || _plugins.EnableGoogleGeocoding))
+@if (_plugins.GoogleCloudApiKey.IsSet() && (_plugins.EnableGoogleMaps || _plugins.EnableGoogleGeocoding))
 {
-    <script async defer src="@string.Format("https://maps.googleapis.com/maps/api/js?key={0}&callback=initGoogleMapsComplete{1}", _plugins.GoogleMapsApiKey, _plugins.EnableGoogleGeocoding ? "&libraries=places" : "")"></script>
+    <script async defer src="@string.Format("https://maps.googleapis.com/maps/api/js?key={0}&callback=initGoogleMapsComplete{1}", _plugins.GoogleCloudApiKey, _plugins.EnableGoogleGeocoding ? "&libraries=places" : "")"></script>
 }

--- a/projects/Hood.UI.Bootstrap3/UI/Templates/_Contact.cshtml
+++ b/projects/Hood.UI.Bootstrap3/UI/Templates/_Contact.cshtml
@@ -47,7 +47,7 @@
         </div>
     </div>
 </div>
-@if (_plugins.EnableGoogleMaps && _plugins.GoogleMapsApiKey.IsSet() && _basicSettings.Address.IsGeoLocated())
+@if (_plugins.EnableGoogleMaps && _plugins.GoogleCloudApiKey.IsSet() && _basicSettings.Address.IsGeoLocated())
 {
     <div class="google-map" data-lat="@_basicSettings.Address?.Latitude" data-long="@_basicSettings.Address?.Longitude" data-marker="@Engine.Settings.Basic.FullTitle" data-zoom="12"></div>
 }

--- a/projects/Hood.UI.Bootstrap4/UI/Shared/_Scripts_Google.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Shared/_Scripts_Google.cshtml
@@ -2,7 +2,7 @@
     IntegrationSettings _plugins = Engine.Settings.Integrations;
 }
 <script src="https://cdn.jsdelivr.net/npm/hoodcms@4.1.6/js/app/google.min.js"></script>
-@if (_plugins.GoogleMapsApiKey.IsSet() && (_plugins.EnableGoogleMaps || _plugins.EnableGoogleGeocoding))
+@if (_plugins.GoogleCloudApiKey.IsSet() && (_plugins.EnableGoogleMaps || _plugins.EnableGoogleGeocoding))
 {
-    <script async defer src="@string.Format("https://maps.googleapis.com/maps/api/js?key={0}&callback=initGoogleMapsComplete{1}", _plugins.GoogleMapsApiKey, _plugins.EnableGoogleGeocoding ? "&libraries=places" : "")"></script>
+    <script async defer src="@string.Format("https://maps.googleapis.com/maps/api/js?key={0}&callback=initGoogleMapsComplete{1}", _plugins.GoogleCloudApiKey, _plugins.EnableGoogleGeocoding ? "&libraries=places" : "")"></script>
 }

--- a/projects/Hood.UI.Bootstrap4/UI/Templates/_Contact.cshtml
+++ b/projects/Hood.UI.Bootstrap4/UI/Templates/_Contact.cshtml
@@ -44,7 +44,7 @@
         </div>
     </div>
 </div>
-@if (_plugins.EnableGoogleMaps && _plugins.GoogleMapsApiKey.IsSet() && _basicSettings.Address.IsGeoLocated())
+@if (_plugins.EnableGoogleMaps && _plugins.GoogleCloudApiKey.IsSet() && _basicSettings.Address.IsGeoLocated())
 {
     <div class="google-map" data-lat="@_basicSettings.Address?.Latitude" data-long="@_basicSettings.Address?.Longitude" data-marker="@Engine.Settings.Basic.FullTitle" data-zoom="12"></div>
 }

--- a/projects/Hood.UI.Core/BaseUI/Property/Index.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Property/Index.cshtml
@@ -8,7 +8,7 @@
     IntegrationSettings _plugins = Engine.Settings.Integrations;
 
 
-    bool maps = _plugins.GoogleMapsApiKey.IsSet() && (_plugins.EnableGoogleMaps || _plugins.EnableGoogleGeocoding);
+    bool maps = _plugins.GoogleCloudApiKey.IsSet() && (_plugins.EnableGoogleMaps || _plugins.EnableGoogleGeocoding);
 }
 
 @section metas {
@@ -65,5 +65,5 @@
 </div>
 @if (maps)
 {
-    <script asp-location="AfterScripts" async defer src="@string.Format("https://maps.googleapis.com/maps/api/js?key={0}&callback=hood.property.initMap{1}", _plugins.GoogleMapsApiKey, _plugins.EnableGoogleGeocoding ? "&libraries=places" : "")"></script>
+    <script asp-location="AfterScripts" async defer src="@string.Format("https://maps.googleapis.com/maps/api/js?key={0}&callback=hood.property.initMap{1}", _plugins.GoogleCloudApiKey, _plugins.EnableGoogleGeocoding ? "&libraries=places" : "")"></script>
 }

--- a/projects/Hood.UI.Core/BaseUI/Shared/_Scripts_GoogleMaps.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Shared/_Scripts_GoogleMaps.cshtml
@@ -1,7 +1,7 @@
 @{
     IntegrationSettings _plugins = Engine.Settings.Integrations;
 }
-@if (_plugins.GoogleMapsApiKey.IsSet() && (_plugins.EnableGoogleMaps || _plugins.EnableGoogleGeocoding))
+@if (_plugins.GoogleCloudApiKey.IsSet() && (_plugins.EnableGoogleMaps || _plugins.EnableGoogleGeocoding))
 {
-    <script async defer src="@string.Format("https://maps.googleapis.com/maps/api/js?key={0}&callback=hood.initGoogleMaps{1}", _plugins.GoogleMapsApiKey, _plugins.EnableGoogleGeocoding ? "&libraries=places" : "")"></script>
+    <script async defer src="@string.Format("https://maps.googleapis.com/maps/api/js?key={0}&callback=hood.initGoogleMaps{1}", _plugins.GoogleCloudApiKey, _plugins.EnableGoogleGeocoding ? "&libraries=places" : "")"></script>
 }

--- a/projects/Hood.UI.Core/BaseUI/Templates/_Contact.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Templates/_Contact.cshtml
@@ -29,7 +29,7 @@
 <div class="py-5 mx-auto" style="max-width:500px">
     <partial name="_ContactForm" model="new ContactFormModel(true, true)" />
 </div>
-@if (_plugins.EnableGoogleMaps && _plugins.GoogleMapsApiKey.IsSet() && _basicSettings.Address.IsGeoLocated())
+@if (_plugins.EnableGoogleMaps && _plugins.GoogleCloudApiKey.IsSet() && _basicSettings.Address.IsGeoLocated())
 {
     <div class="google-map vh-100" data-lat="@_basicSettings.Address?.Latitude" data-long="@_basicSettings.Address?.Longitude" data-marker="@Engine.Settings.Basic.FullTitle" data-zoom="12"></div>
     <partial name="_Scripts_GoogleMaps" />

--- a/readme.md
+++ b/readme.md
@@ -91,8 +91,8 @@ Your own project SQL rides the same path via `--scripts <folder>` (applied after
 
 | You're on | Run, in order |
 |---|---|
-| `6.0.x` | `/sql/06.01.00/10-update-from-6.0.sql` → `/sql/07.00.00/50-update-from-6.1.sql` → the `/sql/07.00.00/*-view-*.sql` scripts |
-| `6.1.x` | `/sql/07.00.00/50-update-from-6.1.sql` → the `/sql/07.00.00/*-view-*.sql` scripts |
+| `6.0.x` | `/sql/06.01.00/10-update-from-6.0.sql` → `/sql/07.00.00/202606021946-update-from-6.1.sql` → `/sql/07.00.00/202606131600-unify-google-apikey.sql` → the `/sql/07.00.00/9*-view-*.sql` scripts |
+| `6.1.x` | `/sql/07.00.00/202606021946-update-from-6.1.sql` → `/sql/07.00.00/202606131600-unify-google-apikey.sql` → the `/sql/07.00.00/9*-view-*.sql` scripts |
 
 The deltas are small and drop no data-bearing columns — see [`sql/README.md`](sql/README.md) for
 exactly what each tier changes.

--- a/sql/07.00.00/00-context-content.sql
+++ b/sql/07.00.00/00-context-content.sql
@@ -1,4 +1,4 @@
--- Apply key 07.00.00/10 | Hood v7.0.0 - Content context. Embedded; applied by hood-schema (DbUp) in LogicalName order.
+-- Apply key 07.00.00/00 | Hood v7.0.0 - Content context. Embedded; applied by hood-schema (DbUp) in LogicalName order.
 -- Content tables — idempotent: the whole block runs only on a database that doesn't
 -- already have it. DbUp journals this script; no EF migration-history table is used.
 IF OBJECT_ID(N'[HoodContent]', 'U') IS NULL

--- a/sql/07.00.00/01-context-hooddb.sql
+++ b/sql/07.00.00/01-context-hooddb.sql
@@ -1,4 +1,4 @@
--- Apply key 07.00.00/20 | Hood v7.0.0 - HoodDb context. Embedded; applied by hood-schema (DbUp) in LogicalName order.
+-- Apply key 07.00.00/01 | Hood v7.0.0 - HoodDb context. Embedded; applied by hood-schema (DbUp) in LogicalName order.
 -- HoodDb tables — idempotent: the whole block runs only on a database that doesn't
 -- already have it. DbUp journals this script; no EF migration-history table is used.
 IF OBJECT_ID(N'[HoodOptions]', 'U') IS NULL

--- a/sql/07.00.00/02-context-identity.sql
+++ b/sql/07.00.00/02-context-identity.sql
@@ -1,4 +1,4 @@
--- Apply key 07.00.00/30 | Hood v7.0.0 - Identity context (standard ASP.NET Identity backend). Embedded; applied by hood-schema (DbUp) in LogicalName order.
+-- Apply key 07.00.00/02 | Hood v7.0.0 - Identity context (standard ASP.NET Identity backend). Embedded; applied by hood-schema (DbUp) in LogicalName order.
 -- Identity tables — idempotent: the whole block runs only on a database that doesn't
 -- already have it. DbUp journals this script; no EF migration-history table is used.
 IF OBJECT_ID(N'[AspNetRoles]', 'U') IS NULL

--- a/sql/07.00.00/03-context-auth0.sql
+++ b/sql/07.00.00/03-context-auth0.sql
@@ -1,4 +1,4 @@
--- Apply key 07.00.00/35 | Hood v7.0.0 - Auth0 context (ALTERNATIVE backend; NOT embedded - the consumer applies this instead of the Identity context).
+-- Apply key 07.00.00/03 | Hood v7.0.0 - Auth0 context (ALTERNATIVE backend; NOT embedded - the consumer applies this instead of the Identity context).
 -- Auth0 tables — idempotent: the whole block runs only on a database that doesn't
 -- already have it. DbUp journals this script; no EF migration-history table is used.
 IF OBJECT_ID(N'[AspNetAuth0Identities]', 'U') IS NULL

--- a/sql/07.00.00/04-context-property.sql
+++ b/sql/07.00.00/04-context-property.sql
@@ -1,4 +1,4 @@
--- Apply key 07.00.00/40 | Hood v7.0.0 - Property context. Embedded; applied by hood-schema (DbUp) in LogicalName order.
+-- Apply key 07.00.00/04 | Hood v7.0.0 - Property context. Embedded; applied by hood-schema (DbUp) in LogicalName order.
 -- Property tables — idempotent: the whole block runs only on a database that doesn't
 -- already have it. DbUp journals this script; no EF migration-history table is used.
 IF OBJECT_ID(N'[HoodProperties]', 'U') IS NULL

--- a/sql/07.00.00/202606021946-update-from-6.1.sql
+++ b/sql/07.00.00/202606021946-update-from-6.1.sql
@@ -1,4 +1,4 @@
--- Apply key 07.00.00/50 | Hood v7.0.0 (6.1.x -> 7.0 upgrade delta). Embedded; applied by hood-schema (DbUp) in LogicalName order.
+-- Apply key 07.00.00/202606021946 | Hood v7.0.0 (6.1.x -> 7.0 upgrade delta). Embedded; applied by hood-schema (DbUp) in LogicalName order.
 -- =============================================================================
 -- Hood CMS — v6.1.x  ->  v7.0 upgrade delta
 -- =============================================================================

--- a/sql/07.00.00/202606131526-converge.sql
+++ b/sql/07.00.00/202606131526-converge.sql
@@ -1,4 +1,4 @@
--- Apply key 07.00.00/60 | Hood v7.0.0 convergence delta (upgraded 6.x -> fresh 7.0 parity). Embedded; applied by hood-schema (DbUp) in LogicalName order.
+-- Apply key 07.00.00/202606131526 | Hood v7.0.0 convergence delta (upgraded 6.x -> fresh 7.0 parity). Embedded; applied by hood-schema (DbUp) in LogicalName order.
 -- =============================================================================
 -- Hood CMS — v7.0 convergence delta
 -- =============================================================================

--- a/sql/07.00.00/202606131600-unify-google-apikey.sql
+++ b/sql/07.00.00/202606131600-unify-google-apikey.sql
@@ -1,0 +1,47 @@
+-- Apply key 07.00.00/202606131600 | Hood v7.0.0 (unify the Google Cloud API key). Embedded; applied by hood-schema (DbUp) in LogicalName order.
+-- =============================================================================
+-- Hood CMS — unify the duplicated Google API key (HOOD-110)
+-- =============================================================================
+-- Idempotent. The reCAPTCHA Enterprise work (HOOD-92) introduced a second Google
+-- Cloud API key (GoogleRecaptchaApiKey) alongside the existing one used for Maps +
+-- Geocoding (GoogleMapsApiKey). v7 collapses both into a single GoogleCloudApiKey.
+--
+-- IntegrationSettings is persisted as a JSON blob in HoodOptions.Value under the key
+-- 'Hood.Models.IntegrationSettings'. This script migrates that stored JSON:
+--   * sets $.GoogleCloudApiKey = first non-empty of (GoogleMapsApiKey, GoogleRecaptchaApiKey)
+--     — only when GoogleCloudApiKey isn't already populated, so re-runs never clobber it;
+--   * strips the two legacy keys.
+-- No-op on a fresh install (the settings row is created lazily on first save).
+-- =============================================================================
+
+SET QUOTED_IDENTIFIER ON;
+SET ANSI_NULLS ON;
+GO
+
+IF EXISTS (SELECT 1 FROM [HoodOptions] WHERE [Id] = 'Hood.Models.IntegrationSettings')
+BEGIN
+    DECLARE @value NVARCHAR(MAX) =
+        (SELECT [Value] FROM [HoodOptions] WHERE [Id] = 'Hood.Models.IntegrationSettings');
+
+    -- Only seed the unified key when it isn't already set (keeps the script re-runnable).
+    IF NULLIF(JSON_VALUE(@value, '$.GoogleCloudApiKey'), '') IS NULL
+    BEGIN
+        DECLARE @unified NVARCHAR(MAX) =
+            COALESCE(
+                NULLIF(JSON_VALUE(@value, '$.GoogleMapsApiKey'), ''),
+                NULLIF(JSON_VALUE(@value, '$.GoogleRecaptchaApiKey'), '')
+            );
+
+        IF @unified IS NOT NULL
+            SET @value = JSON_MODIFY(@value, '$.GoogleCloudApiKey', @unified);
+    END
+
+    -- Drop the legacy keys (lax JSON_MODIFY to NULL deletes them; no-op if already absent).
+    SET @value = JSON_MODIFY(@value, '$.GoogleMapsApiKey', NULL);
+    SET @value = JSON_MODIFY(@value, '$.GoogleRecaptchaApiKey', NULL);
+
+    UPDATE [HoodOptions]
+    SET [Value] = @value
+    WHERE [Id] = 'Hood.Models.IntegrationSettings';
+END
+GO

--- a/sql/07.00.00/90-view-contentviews.sql
+++ b/sql/07.00.00/90-view-contentviews.sql
@@ -1,4 +1,4 @@
--- Apply key 07.00.00/70 | Hood v7.0.0 - HoodContentViews reporting view (idempotent DROP/CREATE). Embedded; applied by hood-schema (DbUp) in LogicalName order.
+-- Apply key 07.00.00/90 | Hood v7.0.0 - HoodContentViews reporting view (idempotent DROP/CREATE). Embedded; applied by hood-schema (DbUp) in LogicalName order.
 IF EXISTS(select * FROM sys.views where name = 'HoodContentViews') DROP VIEW HoodContentViews
 GO
 CREATE VIEW HoodContentViews AS

--- a/sql/07.00.00/91-view-propertyviews.sql
+++ b/sql/07.00.00/91-view-propertyviews.sql
@@ -1,4 +1,4 @@
--- Apply key 07.00.00/80 | Hood v7.0.0 - HoodPropertyViews reporting view (idempotent DROP/CREATE). Embedded; applied by hood-schema (DbUp) in LogicalName order.
+-- Apply key 07.00.00/91 | Hood v7.0.0 - HoodPropertyViews reporting view (idempotent DROP/CREATE). Embedded; applied by hood-schema (DbUp) in LogicalName order.
 IF EXISTS(select * FROM sys.views where name = 'HoodPropertyViews') DROP VIEW HoodPropertyViews
 GO
 CREATE VIEW HoodPropertyViews AS

--- a/sql/07.00.00/92-view-userprofiles.sql
+++ b/sql/07.00.00/92-view-userprofiles.sql
@@ -1,7 +1,7 @@
--- Apply key 07.00.00/95 | Hood v7.0.0 - HoodAuth0UserProfiles view (ALTERNATIVE backend; NOT embedded - the consumer applies this instead of HoodUserProfiles).
-IF EXISTS(select * FROM sys.views where name = 'HoodAuth0UserProfiles') DROP VIEW HoodAuth0UserProfiles
+-- Apply key 07.00.00/92 | Hood v7.0.0 - HoodUserProfiles reporting view (idempotent DROP/CREATE). Embedded; applied by hood-schema (DbUp) in LogicalName order.
+IF EXISTS(select * FROM sys.views where name = 'HoodUserProfiles') DROP VIEW HoodUserProfiles
 GO
-CREATE VIEW HoodAuth0UserProfiles AS
+CREATE VIEW HoodUserProfiles AS
 SELECT 
 	AspNetUsers.Id, 
 	AspNetUsers.UserName, 
@@ -24,16 +24,8 @@ SELECT
 	AspNetUsers.DeliveryAddressJson,	
 	AspNetUsers.CreatedOn,	
 	AspNetUsers.UserVars,
+	AspNetUsers.AccessFailedCount, 
 	COUNT(AspNetRoles.Name) AS RoleCount,
-	(
-		SELECT 
-			*
-		FROM 
-			AspNetAuth0Identities
-		WHERE 
-			AspNetAuth0Identities.LocalUserId = AspNetUsers.Id
-		FOR JSON AUTO
-	) AS Auth0UsersJson,
 	(
 		SELECT 
 			AspNetRoles.Id, AspNetRoles.Name, AspNetRoles.NormalizedName 
@@ -86,5 +78,6 @@ GROUP BY
 	AspNetUsers.BillingAddressJson,	
 	AspNetUsers.DeliveryAddressJson,	
 	AspNetUsers.CreatedOn,	
-	AspNetUsers.UserVars
+	AspNetUsers.UserVars,
+	AspNetUsers.AccessFailedCount
 GO

--- a/sql/07.00.00/93-view-auth0userprofiles.sql
+++ b/sql/07.00.00/93-view-auth0userprofiles.sql
@@ -1,7 +1,7 @@
--- Apply key 07.00.00/90 | Hood v7.0.0 - HoodUserProfiles reporting view (idempotent DROP/CREATE). Embedded; applied by hood-schema (DbUp) in LogicalName order.
-IF EXISTS(select * FROM sys.views where name = 'HoodUserProfiles') DROP VIEW HoodUserProfiles
+-- Apply key 07.00.00/93 | Hood v7.0.0 - HoodAuth0UserProfiles view (ALTERNATIVE backend; NOT embedded - the consumer applies this instead of HoodUserProfiles).
+IF EXISTS(select * FROM sys.views where name = 'HoodAuth0UserProfiles') DROP VIEW HoodAuth0UserProfiles
 GO
-CREATE VIEW HoodUserProfiles AS
+CREATE VIEW HoodAuth0UserProfiles AS
 SELECT 
 	AspNetUsers.Id, 
 	AspNetUsers.UserName, 
@@ -24,8 +24,16 @@ SELECT
 	AspNetUsers.DeliveryAddressJson,	
 	AspNetUsers.CreatedOn,	
 	AspNetUsers.UserVars,
-	AspNetUsers.AccessFailedCount, 
 	COUNT(AspNetRoles.Name) AS RoleCount,
+	(
+		SELECT 
+			*
+		FROM 
+			AspNetAuth0Identities
+		WHERE 
+			AspNetAuth0Identities.LocalUserId = AspNetUsers.Id
+		FOR JSON AUTO
+	) AS Auth0UsersJson,
 	(
 		SELECT 
 			AspNetRoles.Id, AspNetRoles.Name, AspNetRoles.NormalizedName 
@@ -78,6 +86,5 @@ GROUP BY
 	AspNetUsers.BillingAddressJson,	
 	AspNetUsers.DeliveryAddressJson,	
 	AspNetUsers.CreatedOn,	
-	AspNetUsers.UserVars,
-	AspNetUsers.AccessFailedCount
+	AspNetUsers.UserVars
 GO

--- a/sql/README.md
+++ b/sql/README.md
@@ -30,7 +30,7 @@ sqlcmd -S <server> -d <db> -i sql/latest.sql
 
 `sql/latest.sql` creates all tables and the reporting views for the **standard ASP.NET Identity** backend.
 
-> Using the alternative **Auth0** backend instead? It's mutually exclusive with standard Identity (it recreates `AspNetUsers`). Apply `sql/07.00.00/35-context-auth0.sql` + `sql/07.00.00/95-view-auth0userprofiles.sql` instead of the Identity parts.
+> Using the alternative **Auth0** backend instead? It's mutually exclusive with standard Identity (it recreates `AspNetUsers`). Apply `sql/07.00.00/03-context-auth0.sql` + `sql/07.00.00/93-view-auth0userprofiles.sql` instead of the Identity parts.
 
 ## Upgrading an existing database
 
@@ -39,11 +39,12 @@ Prefer the runner above — it does fresh + upgrade in one step. To upgrade by h
 ```bash
 # 6.0.x only — bring the database to the 6.1 baseline first:
 sqlcmd -S <server> -d <db> -i sql/06.01.00/10-update-from-6.0.sql
-# 6.0.x and 6.1.x — the 7.0 delta + views:
-sqlcmd -S <server> -d <db> -i sql/07.00.00/50-update-from-6.1.sql
-sqlcmd -S <server> -d <db> -i sql/07.00.00/70-view-contentviews.sql
-sqlcmd -S <server> -d <db> -i sql/07.00.00/80-view-propertyviews.sql
-sqlcmd -S <server> -d <db> -i sql/07.00.00/90-view-userprofiles.sql
+# 6.0.x and 6.1.x — the 7.0 delta, data migrations + views (in filename order):
+sqlcmd -S <server> -d <db> -i sql/07.00.00/202606021946-update-from-6.1.sql
+sqlcmd -S <server> -d <db> -i sql/07.00.00/202606131600-unify-google-apikey.sql
+sqlcmd -S <server> -d <db> -i sql/07.00.00/90-view-contentviews.sql
+sqlcmd -S <server> -d <db> -i sql/07.00.00/91-view-propertyviews.sql
+sqlcmd -S <server> -d <db> -i sql/07.00.00/92-view-userprofiles.sql
 ```
 
 (Apply scripts in folder-then-filename order — the `MM.mm.pp/SS` key **is** the apply order.)
@@ -56,7 +57,7 @@ Idempotent + forward-only structural cleanup that 6.1 applied:
 - Drops the removed `HoodAddresses` table. **Destructive** — v7 has no such table; a 6.0 site with address data should migrate it out first (it's empty in the stock install).
 - Drops columns removed in 6.1: `AspNetUsers.Latitude` / `.Longitude` and `HoodContent.Notes` / `.SystemNotes` / `.UserVars` (nothing in v7 reads them).
 
-### What `07.00.00/50-update-from-6.1.sql` does (6.1.x → 7.0)
+### What `07.00.00/202606021946-update-from-6.1.sql` does (6.1.x → 7.0)
 
 The v7 delta is small and **drops no data-bearing base-table columns**:
 
@@ -69,11 +70,15 @@ The v7 delta is small and **drops no data-bearing base-table columns**:
 
 Consumers on the 6.1.x baseline take a **clean, zero-data-loss** upgrade — verified that nothing reads any removed field.
 
-### What `07.00.00/60-converge.sql` does (upgrade → fresh parity)
+### What `07.00.00/202606131526-converge.sql` does (upgrade → fresh parity)
 
 Idempotent convergence delta that runs after the update tier and before the views, so an **upgraded** 6.x database lands on the *same* schema as a **fresh** install. On a fresh install it's a no-op.
 
 - Relaxes `AspNetUsers.Anonymous` to nullable (6.x carried it `NOT NULL`; a fresh v7 install models it nullable).
+
+### What `07.00.00/202606131600-unify-google-apikey.sql` does (data migration)
+
+Idempotent data migration for the stored `IntegrationSettings` JSON (HOOD-110). The reCAPTCHA Enterprise work added a second Google Cloud API key (`GoogleRecaptchaApiKey`) alongside the existing Maps/Geocoding key (`GoogleMapsApiKey`); v7 collapses both into one `GoogleCloudApiKey`. The script seeds the unified key from the first non-empty legacy value and strips the old keys. No-op on a fresh install (the settings row is created lazily on first save) and on re-run (only seeds when the unified key is unset).
 
 (The other historical drift converges via the fresh DDL itself — fresh installs now create the `AuthorId` / `UserId` / `AgentId` columns as `nvarchar(450)` **+ indexed**, the shape upgraded DBs already carry, and keep `AspNetRoles.RemoteId`. So there's nothing for the converge delta to alter for those.)
 
@@ -96,11 +101,17 @@ Hood commits to **`fresh == upgrade`** — a database upgraded through the scrip
    dotnet ef migrations script --idempotent --context <Context> -o ../../sql/07.00.00/NN-context-<name>.sql
    ```
    (Strip the UTF-8 BOM EF writes, re-add the `-- Apply key …` banner line, and keep the `SET QUOTED_IDENTIFIER ON; SET ANSI_NULLS ON;` preamble at the top of `latest.sql` — the Identity filtered indexes and the views require it.)
-4. Hand-write the matching upgrade delta as a **new** `MM.mm.pp/SS-<name>.sql` script (next free sequence, gapped) and document it above.
+4. Hand-write the matching upgrade delta as a **new** `MM.mm.pp/<yyyyMMddHHmm>-<name>.sql` script (timestamp-prefixed — typically mirroring the EF migration that authored it) and document it above. **While a version is in RC** the structural-snapshot scripts can be regenerated and the tier reorganised freely (nothing has run in production); **once it ships GA** the migrations are locked — only ever append a new timestamped script.
 
 ## Script ordering & layout
 
-Scripts live in **zero-padded version folders** (`MM.mm.pp`) with a **gapped numeric sequence** per file (`SS-<name>.sql`), and that folder-then-sequence key **is** the apply order. Every component is padded (including the major, so `07.00.00` sorts before a future `10.00.00`, and `SS` so `90` sorts after `10`); the sequence is **gapped by 10s** so new scripts can be wedged between existing ones without renumbering. Ordering never relies on alphabetical accidents; the version is carried by the folder + the `-- Apply key …` header banner + the `HoodOptions['Hood.Version']` stamp.
+Scripts live in **zero-padded version folders** (`MM.mm.pp`, padded so `07.00.00` sorts before a future `10.00.00`), and the folder-then-filename key **is** the apply order — DbUp applies embedded scripts in ordinal `LogicalName` order. **Within** a folder the filename prefix encodes a *phase*:
+
+- **Structural snapshots** — the per-context table DDL — use a low fixed band (`00`–`0x`). These are **regenerated** from the EF model, not point-in-time history, so they carry a stable ordinal, not a date.
+- **Forward deltas & data-migrations** — the true append-only migrations — use a **`yyyyMMddHHmm` timestamp** prefix, typically the timestamp of the EF migration that authored them. Timestamps never collide across parallel branches and never need renumbering.
+- **Reporting views** — also regenerated (idempotent DROP/CREATE) — use a high fixed band (`9x`) so they always apply last.
+
+Ordinal sort gives `0x` < `2026…` < `9x`, so the two fixed bands bookend the timestamped middle. Ordering never relies on alphabetical accidents; the version is carried by the folder + the `-- Apply key …` header banner + the `HoodOptions['Hood.Version']` stamp. While a tier is in RC the prefixes are renumbered to stay sequential; after GA they're append-only.
 
 ```
 sql/
@@ -108,17 +119,21 @@ sql/
   06.01.00/
     10-update-from-6.0.sql              # 6.0.x -> 6.1 upgrade delta (drop legacy FKs/columns/HoodAddresses)
   07.00.00/
-    10-context-content.sql             # per-context table DDL (generated, idempotent)
-    20-context-hooddb.sql
-    30-context-identity.sql            # standard ASP.NET Identity backend
-    35-context-auth0.sql               # ALTERNATIVE Auth0 backend — NOT embedded; consumer applies instead of Identity
-    40-context-property.sql
-    50-update-from-6.1.sql             # 6.1.x -> 7.0 upgrade delta
-    60-converge.sql                    # convergence delta (upgraded 6.x -> fresh parity)
-    70-view-contentviews.sql           # reporting views (idempotent DROP/CREATE)
-    80-view-propertyviews.sql
-    90-view-userprofiles.sql
-    95-view-auth0userprofiles.sql      # ALTERNATIVE Auth0 backend — NOT embedded; consumer applies instead of userprofiles
+    # structural snapshots — low band (00-0x), regenerated from the EF model
+    00-context-content.sql             # per-context table DDL (generated, idempotent)
+    01-context-hooddb.sql
+    02-context-identity.sql            # standard ASP.NET Identity backend
+    03-context-auth0.sql               # ALTERNATIVE Auth0 backend — NOT embedded; consumer applies instead of Identity
+    04-context-property.sql
+    # forward deltas & data-migrations — yyyyMMddHHmm timestamp, append-only
+    202606021946-update-from-6.1.sql   # 6.1.x -> 7.0 upgrade delta
+    202606131526-converge.sql          # convergence delta (upgraded 6.x -> fresh parity)
+    202606131600-unify-google-apikey.sql  # data migration — collapse the two Google keys into GoogleCloudApiKey
+    # reporting views — high band (9x), regenerated (idempotent DROP/CREATE)
+    90-view-contentviews.sql
+    91-view-propertyviews.sql
+    92-view-userprofiles.sql
+    93-view-auth0userprofiles.sql      # ALTERNATIVE Auth0 backend — NOT embedded; consumer applies instead of userprofiles
 ```
 
-The runner embeds these from `Hood.Core` (`Hood.Core.csproj`) and applies them by `LogicalName` order — i.e. the `MM.mm.pp/SS` key — **excluding** `latest.sql` and the two Auth0-backend scripts. Apply order: contexts → update → (`07.00.00/60` convergence delta, when present) → views.
+The runner embeds these from `Hood.Core` (`Hood.Core.csproj`) and applies them by ordinal `LogicalName` order **excluding** `latest.sql` and the two Auth0-backend scripts. Apply order: context snapshots → timestamped deltas (update → converge → data migrations) → views.


### PR DESCRIPTION
Clears the four Bug-labelled backlog issues for the **Hood CMS v7** project in one branch — one commit per bug, plus a gate-compliance commit. Verified end-to-end against a fresh SQL Server (full suite **46/46**) and `validate_code.sh` is green (CSharpier + InspectCode, zero findings).

## ⚠️ Breaking changes (public API)

`IntegrationSettings.GoogleMapsApiKey` and `IntegrationSettings.GoogleRecaptchaApiKey` are **removed**, replaced by a single `IntegrationSettings.GoogleCloudApiKey`. Any consumer code, themes or views referencing the old property names must update to `GoogleCloudApiKey`. **Stored values migrate automatically** via `sql/07.00.00/202606131600-unify-google-apikey.sql` (idempotent `JSON_MODIFY`, seeds the unified key from the first non-empty legacy value, no-op on fresh installs).

## Changes

### HOOD-80 — `MediaBase` ctor assigning `thumbUrl` to Small/Medium/LargeUrl
The convenience ctor used `thumbUrl` as the "set" branch for three URL fields, so any caller passing distinct size URLs silently got the thumbnail. Each ternary now uses its own parameter. All current callers pass only `url`, so nothing relied on the bug. Adds unit tests for the fallback logic.

### HOOD-111 — geocoding 500s instead of failing silently
`GeocodeAddress` ran the geocoder via a blocking `.Result`, so an invalid/denied key, over-quota account or transient HTTP error threw as an `AggregateException` — which the call sites' `catch (GoogleGeocodingException)` never caught, surfacing as a 500. Now wrapped in a broad try/catch inside `AddressService`: logs via `Engine.Logs`, returns `null`, every caller falls back gracefully. Also guards a previously-unchecked `loc.Coordinates` deref in `BlmFileImporter`.

### HOOD-110 — duplicated Google API key unified
reCAPTCHA Enterprise introduced a second Google Cloud key alongside the Maps/Geocoding one. Collapsed both into `GoogleCloudApiKey` (model, `RecaptchaService`, `AddressService`, all theme views, the admin Integrations form). Includes the data migration above. The `07.00.00` SQL tier is reorganised onto a **phase + timestamp** naming scheme (structural snapshots `00-0x`, forward deltas / data-migrations `yyyyMMddHHmm`, views `9x`) — DbUp's ordinal `LogicalName` sort gives `0x` < `2026…` < `9x`. Pre-GA, so the tier isn't locked.

### HOOD-72 — HTTP-level integration smoke tests
`WebApplicationFactory`-based smoke suite: boots the app in-process against the test DB and asserts the anonymous `/account/login` page renders, then after a **genuine cookie login** drives `/admin/users`, `/admin/roles` (the HOOD-66 role views) and the content list with no 500s. Production startup is unchanged — Engine init already runs in-pipeline (WAF executes it); the factory invokes the same post-build `LoadHoodAsync()` against the test host. `SkippableFact`-gated on a database; runs in CI, skips without one. Standard-Identity only (Auth0 is a separate backend).

### HOOD-115 — `RecaptchaTagHelper` NRE when settings unset (rider)
Found by the HOOD-72 smoke tests: `Engine.Settings.Integrations` is null when the `IntegrationSettings` option row doesn't exist (never-saved / partially-installed DB), so the `<recaptcha>` tag on login/register/contact NRE'd → 500. Null-guarded to render nothing in that case. Verified: with the row deleted, `/account/login` renders 200.

## Linear
- HOOD-80
- HOOD-111
- HOOD-110
- HOOD-72
- HOOD-115 (rider — NRE found by the smoke tests)
- HOOD-112 (SQL-naming convention — decided & implemented here)

## Test plan
- [x] `dotnet test` — 46/46 against a fresh SQL Server (smoke, schema-parity, view-query, unit)
- [x] `validate_code.sh` — CSharpier + InspectCode clean
- [x] Schema applied fresh via `hood-schema` in the new phase+timestamp order
