### PR TITLE
HOOD-116: Always publish RC on merge; keep PR path-filters

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -7,18 +7,10 @@ name: Backend
 # PRs build + test only (the publish job is gated on push/release).
 
 on:
+  # No paths filter on push: every merge to master publishes an RC so the NuGet and
+  # npm prereleases stay in lockstep, regardless of which paths the merge touched.
   push:
     branches: [master]
-    paths:
-      - 'projects/**'
-      - 'Hood.sln'
-      - 'Directory.Build.props'
-      - 'global.json'
-      - '.github/workflows/backend.yml'
-      - 'validate_code.sh'
-      - '.editorconfig'
-      - 'Hood.sln.DotSettings'
-      - '.config/**'
   pull_request:
     paths:
       - 'projects/**'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,17 +8,10 @@ name: Frontend
 # PRs build only (the publish job is gated on push/release).
 
 on:
+  # No paths filter on push: every merge to master publishes an RC so the npm and
+  # NuGet prereleases stay in lockstep, regardless of which paths the merge touched.
   push:
     branches: [master]
-    paths:
-      - 'projects/Hood.Development/src/**'
-      - 'projects/Hood.Development/Views/**'
-      - 'projects/Hood.Development/Themes/**'
-      - 'projects/Hood.Development/gulpfile.js'
-      - 'projects/Hood.Development/package.json'
-      - 'projects/Hood.Development/yarn.lock'
-      - 'projects/Hood.Development/tsconfig*.json'
-      - '.github/workflows/frontend.yml'
   pull_request:
     paths:
       - 'projects/Hood.Development/src/**'


### PR DESCRIPTION
Fixes inconsistent RC publishing on merge.

## Problem
`backend.yml` and `frontend.yml` applied the **same `paths:` filter to both the `push: [master]` and `pull_request` triggers**, so a merge only published its RC when the changed files matched that workflow's path list. Merges that touched `sql/**`, repo-root files, or only one side's projects published an incomplete/empty set — and the NuGet vs npm RCs drifted out of the lockstep the frontend workflow explicitly intends.

## Change
- Remove the `paths:` block from the **`push: branches: [master]`** trigger in both workflows → every merge always builds + publishes an `rc.N`.
- **Keep** the `pull_request` `paths:` filters → PRs still build/validate only when relevant files change.
- `release` trigger and all job-level `if:` gating unchanged.

## Effect
| Event | Before | After |
|---|---|---|
| Merge to master | publishes only if paths match | **always** publishes RC (NuGet + npm, in lockstep) |
| PR | builds only if paths match | unchanged |
| Release tag | publishes stable | unchanged |

Note: this PR itself touches `.github/workflows/**` (in both PR filters), so both workflows run on it.

## Linear
- HOOD-116
