### PR TITLE
HOOD-129: document the project/package layout in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,23 @@ The deltas are small and drop no data-bearing columns — see [`sql/README.md`](
 exactly what each tier changes.
 
 
+## Project layout
+
+Hood is split into focused packages under `projects/`, each published as its own NuGet package (except the test project):
+
+| Package | Purpose |
+|---|---|
+| `Hood` | Complete Hood CMS package — all default controllers, packaged with the Bootstrap 4 default theme. |
+| `Hood.Core` | DI / runtime engine — base controllers, attributes, contexts, extensions, filters. |
+| `Hood.Admin` | Admin-area controllers. |
+| `Hood.Development` | Dev-time helpers. |
+| `Hood.SchemaTool` | CLI to apply the database schema (idempotent, forward-only) in a deploy pipeline. |
+| `Hood.UI.Core` | Base UI scaffolding and shared view components. |
+| `Hood.UI.Admin` | Admin UI — Areas and views. |
+| `Hood.UI.Bootstrap3` / `Hood.UI.Bootstrap4` | Bootstrap 3 / 4 themed UI variants. |
+| `Hood.Tests` | Test suite (not published). |
+
+
 ## Full documentation
 
 Documentation is a work in progress. The most useful references today:


### PR DESCRIPTION
Adds a **Project layout** table to `readme.md` listing each `projects/` package and its one-line purpose, so the package breakdown is documented publicly in the repo.

Docs-only — no code, schema, or API change.
