### PR TITLE
HOOD-132, HOOD-135: db restore provider seam + adoption DX polish

### DIFF
--- a/projects/Hood.Development/README.md
+++ b/projects/Hood.Development/README.md
@@ -15,6 +15,30 @@ npm install hoodcms
 pnpm add hoodcms
 ```
 
+## Adopting Hood tooling — one mental model
+
+`hoodcms` exposes three tooling surfaces, and they all adopt the **same way** — so once you've
+learned one, you've learned all three:
+
+| Surface | Entry | Extend with |
+|---|---|---|
+| **Build** presets (rollup + gulp) | `hoodcms/build` | `hoodRollup({ … })` · `registerHoodTasks(gulp, { … })` |
+| **Dev** command layer | `hoodcms/dev` | `defineTasks({ … })` |
+| **Database** (schema + restore) | `hoodcms` bin → `db <sub>` | `defineTasks({ schemaUpgrade, restoreProviders })` |
+
+Every surface follows the same three rules:
+
+- **Zero-config by default.** A vanilla consumer (e.g. **Wards**) runs on Hood's defaults with
+  no config file — `hoodcms up`, `hoodRollup({ entries })`, `db upgrade` all just work.
+- **Extend, don't clone.** You pass a typed factory an options/overrides object; you never copy
+  Hood's gulpfile, rollup config, dev tasks, or schema runner into your repo. An extension
+  consumer (e.g. **CMEL**) overrides only what differs and inherits the rest.
+- **Conventional & consistent.** The same config-resolution model and override shape across all
+  three, so build, dev, and db feel like one coherent toolkit rather than three bolt-ons.
+
+The rest of this README walks each surface; they're intentionally repetitive because the
+ergonomics are deliberately identical.
+
 ## Using it with Hood CMS
 
 You don't need this package just to **run** Hood — the required CSS/JS are served from

--- a/projects/Hood.Development/README.md
+++ b/projects/Hood.Development/README.md
@@ -63,6 +63,45 @@ npx hoodcms watch      # frontend + backend hot-reload together (one Ctrl+C stop
 npx hoodcms down
 ```
 
+Database commands share a `db <sub>` namespace (the hyphenated forms still work too):
+
+```bash
+npx hoodcms db up                       # start SQL Server only, wait until healthy
+npx hoodcms db upgrade                  # create-if-absent + apply the Hood schema (idempotent)
+npx hoodcms db restore dump.bacpac      # restore from a file, then run db upgrade to reconcile
+npx hoodcms db reset                    # nuclear option: drop the DB volume and recreate the stack
+```
+
+#### Restoring a database (`db restore`)
+
+`db restore <file>` is a **generic, file-based** restore: it dispatches by file extension to a
+`RestoreProvider`. The **file path is the entire contract** — where the file came from (a
+`hood cli az pull`, an S3 export, a teammate's dump) never enters this layer, and `hood-schema`
+stays a pure schema-migration tool. Hood ships a built-in `.bacpac` provider via the
+cross-platform `sqlpackage` .NET tool (`dotnet tool install --global microsoft.sqlpackage`),
+connecting over the host TCP port — no Docker coupling.
+
+Restore is **destructive** — it overwrites the target database — so it requires an interactive
+`yes`, or a `--force` flag in non-interactive shells. A restored database may be behind the
+current schema, so run `db upgrade` afterwards (DbUp's journal reconciles idempotently). If a
+restore leaves the database wedged, `db reset` is the nuclear recovery path.
+
+Register your own provider (e.g. `.bak`, `.sql`) without forking, in `hood.dev.ts`:
+
+```ts
+import { defineTasks } from 'hoodcms/dev';
+
+export default defineTasks({
+  restoreProviders: [
+    {
+      extensions: ['.sql'],
+      describe: 'Plain T-SQL script',
+      restore: ({ file, connection, task }) => task.run('sqlcmd', ['-S', '127.0.0.1,14331', '-i', file]),
+    },
+  ],
+});
+```
+
 It's zero-config by default; drop in an optional, fully-typed `hood.dev.ts` to override
 settings or register your own targets:
 

--- a/projects/Hood.Development/dev/index.ts
+++ b/projects/Hood.Development/dev/index.ts
@@ -25,6 +25,7 @@ import { pathToFileURL } from 'node:url';
 import { loadEnv, resolveConnection } from './lib/connection';
 import { compose, waitForDb } from './lib/docker';
 import { parallel, run } from './lib/process';
+import { builtinRestoreProviders } from './lib/restore';
 import { BASE_TASK_ALIASES, baseTasks } from './lib/tasks';
 import type {
     DevConfig,
@@ -115,6 +116,8 @@ export function resolveConfig(config: DevConfig, cwd: string): ResolvedConfig {
         connection: config.connection,
         saPassword: config.saPassword ?? 'Hood_Dev_Passw0rd!',
         envFiles: config.envFiles ?? ['.env.local'],
+        // Built-ins first, consumer providers last — so a consumer can override an extension.
+        restoreProviders: [...builtinRestoreProviders(), ...(config.restoreProviders ?? [])],
         watch: {
             frontend: config.watch?.frontend ?? [
                 ['pnpm', 'run', 'watch-scss'],
@@ -166,7 +169,12 @@ export function parseArgs(argv: string[]): ParsedArgs {
         }
     }
 
-    const command = positionals.shift() ?? '';
+    let command = positionals.shift() ?? '';
+    // `db <sub>` namespace → the `db-<sub>` target (db up / db upgrade / db restore / db reset).
+    // The hyphenated names still work when typed directly, so this is purely additive.
+    if (command === 'db' && positionals.length > 0) {
+        command = `db-${positionals.shift()}`;
+    }
     return { command, args: positionals, flags };
 }
 

--- a/projects/Hood.Development/dev/index.ts
+++ b/projects/Hood.Development/dev/index.ts
@@ -207,18 +207,33 @@ function makeContext(
     return ctx;
 }
 
-/** Print the available commands. */
+/** Display a registry key as it's typed: `db-restore` → `db restore`, so help mirrors the CLI. */
+function displayName(name: string): string {
+    return name.startsWith('db-') ? `db ${name.slice(3)}` : name;
+}
+
+/** Print the available commands, with the `db <sub>` family grouped under its own heading. */
 function printHelp(registry: Map<string, TaskDefinition>): void {
     const names = [...registry.keys()].sort();
-    const width = Math.max(...names.map((n) => n.length), ...Object.keys(BASE_TASK_ALIASES).map((a) => a.length));
+    const dbNames = names.filter((n) => n.startsWith('db-'));
+    const general = names.filter((n) => !n.startsWith('db-'));
+
+    const width = Math.max(
+        ...names.map((n) => displayName(n).length),
+        ...Object.keys(BASE_TASK_ALIASES).map((a) => a.length),
+    );
+    const line = (name: string, describe: string) => console.log(`  ${name.padEnd(width)}  ${describe}`);
+
     console.log('hoodcms — Hood CMS local dev commands\n');
     console.log('Usage: hoodcms <command> [--connection <str>] [--config <hood.dev.ts>]\n');
+
     console.log('Commands:');
-    for (const name of names) {
-        console.log(`  ${name.padEnd(width)}  ${registry.get(name)!.describe}`);
-    }
-    for (const [alias, target] of Object.entries(BASE_TASK_ALIASES)) {
-        console.log(`  ${alias.padEnd(width)}  Alias for "${target}".`);
+    for (const name of general) line(displayName(name), registry.get(name)!.describe);
+    for (const [alias, target] of Object.entries(BASE_TASK_ALIASES)) line(alias, `Alias for "${target}".`);
+
+    if (dbNames.length > 0) {
+        console.log('\nDatabase (db <sub>):');
+        for (const name of dbNames) line(displayName(name), registry.get(name)!.describe);
     }
 }
 

--- a/projects/Hood.Development/dev/lib/restore.ts
+++ b/projects/Hood.Development/dev/lib/restore.ts
@@ -1,0 +1,91 @@
+/**
+ * hoodcms/dev — the `db restore <file>` provider seam (HOOD-132).
+ *
+ * A generic, file-based restore primitive: a producer (e.g. `hood cli az pull`, an S3 export,
+ * a teammate's dump) writes a local file, and `db restore <file>` dispatches by extension to a
+ * `RestoreProvider`. The file path is the entire contract — no source (Azure, S3, …) ever enters
+ * this layer, and `hood-schema` stays a pure schema-migration tool. Consumers register extra
+ * providers through `hood.dev.ts` without forking.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline';
+import type { RestoreProvider, TaskContext } from './types';
+
+/**
+ * `.bacpac` via sqlpackage — the `Microsoft.SqlPackage` cross-platform .NET tool. Imports over
+ * the host TCP port using the shared connection, so there is **no Docker coupling**. sqlpackage
+ * drops + recreates the database internally, which also sidesteps the `.bak` `RESTORING`-state
+ * footgun — so the DB must NOT be pre-created here (no `EnsureDatabase` before restore).
+ *
+ * Install once: `dotnet tool install --global microsoft.sqlpackage`.
+ */
+const bacpacProvider: RestoreProvider = {
+    extensions: ['.bacpac'],
+    describe: 'SQL Server .bacpac import via sqlpackage',
+    restore: ({ file, connection, task }) =>
+        task.run('sqlpackage', [
+            '/Action:Import',
+            `/SourceFile:${file}`,
+            `/TargetConnectionString:${connection}`,
+        ]),
+};
+
+/** Hood's built-in restore providers. `.bacpac` first — the Docker-free, `RESTORING`-safe path. */
+export function builtinRestoreProviders(): RestoreProvider[] {
+    return [bacpacProvider];
+}
+
+/** Resolve the provider for a file by extension. Last match wins, so a consumer overrides a built-in. */
+export function providerFor(providers: RestoreProvider[], file: string): RestoreProvider | undefined {
+    const ext = path.extname(file).toLowerCase();
+    let match: RestoreProvider | undefined;
+    for (const provider of providers) {
+        if (provider.extensions.some((e) => e.toLowerCase() === ext)) match = provider;
+    }
+    return match;
+}
+
+/**
+ * The `db restore <file>` flow: validate the file, confirm (restore is destructive), dispatch to
+ * the extension's provider, then point the user at `db upgrade` to reconcile the schema.
+ */
+export async function runRestore(task: TaskContext): Promise<void> {
+    const file = task.args[0];
+    if (!file) throw new Error('db restore: a file path is required — `hoodcms db restore <file>`.');
+
+    const abs = path.resolve(task.cwd, file);
+    if (!fs.existsSync(abs)) throw new Error(`db restore: file not found: ${abs}`);
+
+    const provider = providerFor(task.config.restoreProviders, abs);
+    if (!provider) {
+        const known = [...new Set(task.config.restoreProviders.flatMap((p) => p.extensions))].join(', ');
+        const ext = path.extname(abs) || '(no extension)';
+        throw new Error(`db restore: no provider for "${ext}". Known extensions: ${known}.`);
+    }
+
+    await confirmDestructive(task, abs, provider.describe);
+
+    const connection = task.connection();
+    task.log(`Restoring ${path.basename(abs)} via ${provider.describe}…`);
+    await provider.restore({ file: abs, connection, task });
+    task.log('Restore complete. Run `hoodcms db upgrade` to reconcile the schema (idempotent).');
+}
+
+/** Destructive-action guard: `--force`/`--yes` skips the prompt; otherwise require an interactive "yes". */
+async function confirmDestructive(task: TaskContext, file: string, describe: string): Promise<void> {
+    if (task.flags.force === true || task.flags.yes === true) return;
+    if (!process.stdin.isTTY) {
+        throw new Error('db restore overwrites the target database. Re-run with --force in a non-interactive shell.');
+    }
+
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const answer = await new Promise<string>((resolve) =>
+        rl.question(
+            `This will OVERWRITE the database from ${path.basename(file)} (${describe}). Type "yes" to continue: `,
+            resolve,
+        ),
+    );
+    rl.close();
+    if (answer.trim().toLowerCase() !== 'yes') throw new Error('db restore: aborted.');
+}

--- a/projects/Hood.Development/dev/lib/tasks.ts
+++ b/projects/Hood.Development/dev/lib/tasks.ts
@@ -9,6 +9,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { resolveSaPassword } from './connection';
+import { runRestore } from './restore';
 import type { TaskContext, TaskDefinition } from './types';
 
 // The native dev URL. Deliberately set via ASPNETCORE_URLS (env) rather than a "Urls" key in
@@ -107,6 +108,19 @@ export function baseTasks(): Record<string, TaskDefinition> {
                 await ctx.waitForDb();
                 const [cmd, ...args] = ctx.config.schemaUpgrade;
                 await ctx.run(cmd, [...args, '--connection', ctx.connection()]);
+            },
+        },
+
+        'db-restore': {
+            describe: 'Restore the DB from a file (`db restore <file>`; .bacpac built-in) — destructive, --force-guarded.',
+            run: (ctx) => runRestore(ctx),
+        },
+
+        'db-reset': {
+            describe: 'Nuclear option: drop the DB volume and recreate the stack (down -v, then up).',
+            run: async (ctx) => {
+                await ctx.compose(['down', '-v']);
+                await ctx.invoke('up');
             },
         },
 

--- a/projects/Hood.Development/dev/lib/types.ts
+++ b/projects/Hood.Development/dev/lib/types.ts
@@ -14,6 +14,29 @@ export interface TaskDefinition {
     run: (ctx: TaskContext) => Promise<void> | void;
 }
 
+/**
+ * A restore source plugged into `db restore <file>` (HOOD-132), dispatched by file extension.
+ * Hood ships a built-in `.bacpac` provider; a consumer registers more through `hood.dev.ts`.
+ */
+export interface RestoreProvider {
+    /** Lower-case extensions (with the dot) this provider handles, e.g. `['.bacpac']`. */
+    extensions: string[];
+    /** One-line description shown in help and dispatch errors. */
+    describe: string;
+    /** Restore `file` into the resolved database. Throw to fail the command. */
+    restore(ctx: RestoreContext): Promise<void> | void;
+}
+
+/** What a `RestoreProvider` receives — the producer→file→provider contract, nothing source-specific. */
+export interface RestoreContext {
+    /** Absolute path to the dump/export file being restored. */
+    file: string;
+    /** The resolved, loopback-pinned host connection string (shared `resolveConnection()` chain). */
+    connection: string;
+    /** The full task context (`run`, `log`, `config`, …). */
+    task: TaskContext;
+}
+
 /** Frontend + backend watch commands wired together by the `watch` target. */
 export interface WatchConfig {
     /** Long-lived frontend watchers, each `[cmd, ...args]` (default: scss + tsc watch via pnpm). */
@@ -56,6 +79,11 @@ export interface DevConfig {
     saPassword?: string;
     /** `.env` files loaded (in order) before resolving config (default: `['.env.local']`). */
     envFiles?: string[];
+    /**
+     * Extra `db restore` providers, or overrides of a built-in by extension (last match wins).
+     * Merged after Hood's built-ins (the `.bacpac` provider) — see HOOD-132.
+     */
+    restoreProviders?: RestoreProvider[];
     /** Watch commands wired together by `dev`. */
     watch?: WatchConfig;
     /** Extra targets, or overrides of a base target by name. */


### PR DESCRIPTION
Two 7.0.1 dev-tooling tickets, one commit each.

## HOOD-132 — `db restore` provider seam + `.bacpac` provider

A generic, file-based `db restore <file>` primitive in `hoodcms/dev`, built on a pluggable `RestoreProvider` interface dispatched by file extension. The **file path is the entire contract** — no source (`hood cli az pull`, S3, a teammate's dump) enters this layer, and `hood-schema` stays a pure schema-migration tool.

- `RestoreProvider` / `RestoreContext` types; consumers register providers via `hood.dev.ts` (last-match-wins, so a built-in can be overridden).
- Built-in `.bacpac` provider via the cross-platform `sqlpackage` .NET tool, over the host TCP port — **no Docker coupling**. sqlpackage drops + recreates internally (sidesteps the `.bak` `RESTORING` footgun), so the DB is not pre-created.
- Connection resolved through the shared `resolveConnection()` chain.
- Destructive-action guard: interactive `yes`, or `--force` in non-TTY shells.
- New `db <sub>` command namespace (`db up` / `upgrade` / `restore` / `reset`) — hyphenated task names still work, so it's purely additive.
- `db reset` (`down -v && up`) as the documented nuclear recovery path.

## HOOD-135 — polish adoption DX to the `hoodcms/dev` bar

- Help groups the db family under a **Database (db <sub>)** heading and renders each as typed (`db upgrade`, `db restore`, …) — db-upgrade is now reachable and discoverable via the conventional `db upgrade` path.
- README gains an **"Adopting Hood tooling — one mental model"** section spanning library + build + dev + db: same zero-config-default, extend-not-clone typed factory, and config-resolution model across all three surfaces, with the vanilla (Wards) and extension (CMEL) paths called out.
- Additive/consistency polish only — no rearchitecture of `hoodcms/build` (HOOD-83) or `hood-schema` (HOOD-85).

## Test plan

- [x] Dev layer type-checks clean under the project base config with `noImplicitAny` (exit 0).
- [x] `db restore` (no file / unknown extension / missing file) all fail with clean, specific errors; `--force` bypasses the TTY confirm.
- [x] `hoodcms help` renders the grouped `db <sub>` surface.
- [ ] `db restore dump.bacpac` against a real SQL Server (needs `sqlpackage` + a `.bacpac` — exercised by adopters).

## Linear

- HOOD-132 — https://linear.app/hood-digital/issue/HOOD-132
- HOOD-135 — https://linear.app/hood-digital/issue/HOOD-135
