### PR TITLE
HOOD-90 - Carry prerelease tag in CDN URLs + CdnFullPath verbatim override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
 # Hood local dev environment — secrets (SA password / connection string). Copied from
-# .env.example; never committed. See DOCKER.md.
+# .env.example; never committed. See docs/docker.md.
 .env.local
 
 # User-specific files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 # The SA password is read from ${HOOD_SA_PASSWORD} — there are no hardcoded credentials here.
 # `hoodcms` always supplies it (default + .env.local overlay); for raw `docker compose` you
 # must provide it via --env-file .env.local (copied from .env.example) or your environment.
-# See DOCKER.md for the full walkthrough.
+# See docs/docker.md for the full walkthrough.
 services:
   sqlserver:
     image: mcr.microsoft.com/mssql/server:2022-latest

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,44 @@
+# Hood configuration (`appsettings.json`)
+
+Reference for the `Hood` configuration section a consumer app provides. Only settings you need to
+override have to be present; sensible defaults apply otherwise.
+
+> More of this section (the full minimal-consumer reference) is being filled in under HOOD-100.
+
+## CDN asset delivery
+
+Hood's admin and UI CSS/JS are served from a CDN so a consumer doesn't have to publish Hood's
+front-end assets with its app. By default they load from jsDelivr:
+
+```
+https://cdn.jsdelivr.net/npm/hoodcms@{version}/{path}
+```
+
+`{version}` matches the Hood assembly you're running, **including the `-rc.N` prerelease tag** — so
+apps on a prerelease build resolve the matching npm package rather than 404-ing on a stable version
+that isn't published yet.
+
+Three `Hood` settings control where assets load from. Set **at most one**; they resolve in the order
+`BypassCDN` → `CdnFullPath` → `CdnPath` → default.
+
+| Setting | Effect | Use when |
+|---|---|---|
+| `BypassCDN: true` | Serve Hood's assets from your app's own `wwwroot`. | You publish Hood's `wwwroot` assets with your app and want no external dependency. |
+| `CdnPath` | Override the CDN **base** (host + package). Hood still appends `@{version}{path}`. | You mirror the `hoodcms` package on another CDN but want to keep Hood's versioning. |
+| `CdnFullPath` | A **complete** base URL used **verbatim** — Hood appends only `{path}`, never a version segment. **You own the version pin.** | You self-host or mirror the assets at a fixed location, or want to pin a specific version, without overriding the `_Scripts` / `_Styles` views. |
+
+### Example — self-hosted, version-pinned copy
+
+```jsonc
+"Hood": {
+  "CdnFullPath": "https://assets.example.com/hoodcms@7.0.0"
+  // → https://assets.example.com/hoodcms@7.0.0/src/css/admin.css
+}
+```
+
+### Notes
+
+- **`asp-append-version` is a no-op on CDN URLs.** The ASP.NET Core tag helper can only hash local
+  files under `wwwroot`, not remote CDN URLs, so it emits no version suffix on Hood resources — don't
+  rely on it for cache-busting. Content-hashed cache-busting is planned with the manifest pipeline
+  (≥ Hood 7.1).

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,8 +1,8 @@
 # Docker setup — local dev for Hood CMS
 
-The repo ships a [`docker-compose.yml`](docker-compose.yml) that runs **SQL Server + the Hood web host** in containers, so you can build and run the app end-to-end locally in a few minutes. This is the supported way to build & test every PR before it lands.
+The repo ships a [`docker-compose.yml`](../docker-compose.yml) that runs **SQL Server + the Hood web host** in containers, so you can build and run the app end-to-end locally in a few minutes. This is the supported way to build & test every PR before it lands.
 
-This file covers **local dev only**. For repo basics see [readme.md](readme.md).
+This file covers **local dev only**. For repo basics see [readme.md](../readme.md).
 
 > **Framework note:** Hood targets **net10.0 + EF Core 10**. The .NET SDK is pinned via `global.json` and the target framework is centralised in `Directory.Build.props`. Database schema seeding is tracked in HOOD-53.
 
@@ -67,7 +67,7 @@ Even with **no** `.env.local`, `hoodcms` works out of the box: it supplies the d
 | Service | Container | Host port | Purpose |
 |---|---|---|---|
 | `sqlserver` | `hood-sqlserver` | `14331` → 1433 | SQL Server 2022 Express. Data persists in the `sqlserver-data` named volume. |
-| `app` | `hood-app` | `5070` → 8080 | The `Hood.Development` ASP.NET Core host, built from [`Dockerfile`](Dockerfile). |
+| `app` | `hood-app` | `5070` → 8080 | The `Hood.Development` ASP.NET Core host, built from [`Dockerfile`](../Dockerfile). |
 
 Host port `14331` avoids clashes with a native SQL Server (`1433`) or other local dev stacks.
 
@@ -84,7 +84,7 @@ pnpm hoodcms run            # dotnet run, pointed at the Docker SQL Server on 12
 # App available at http://localhost:5070 (or the Kestrel default)
 ```
 
-`pnpm hoodcms run` sets `ConnectionStrings__DefaultConnection` to target the container. Without it, [`appsettings.json`](projects/Hood.Development/appsettings.json) points at `localhost\SQLEXPRESS` for a native SQL Server install.
+`pnpm hoodcms run` sets `ConnectionStrings__DefaultConnection` to target the container. Without it, [`appsettings.json`](../projects/Hood.Development/appsettings.json) points at `localhost\SQLEXPRESS` for a native SQL Server install.
 
 ### Watch mode
 
@@ -92,7 +92,7 @@ pnpm hoodcms run            # dotnet run, pointed at the Docker SQL Server on 12
 
 ## Database state
 
-The stack brings up an **empty** SQL Server. `pnpm hoodcms up` (and `pnpm hoodcms db-upgrade`) apply the schema via the schema tool before the app starts; the app itself does **no** automatic migration or seeding at startup. The full schema/runner reference is in [`sql/README.md`](sql/README.md).
+The stack brings up an **empty** SQL Server. `pnpm hoodcms up` (and `pnpm hoodcms db-upgrade`) apply the schema via the schema tool before the app starts; the app itself does **no** automatic migration or seeding at startup. The full schema/runner reference is in [`sql/README.md`](../sql/README.md).
 
 To open a SQL shell inside the container:
 

--- a/projects/Hood.Core/Engine.cs
+++ b/projects/Hood.Core/Engine.cs
@@ -286,8 +286,9 @@ namespace Hood.Core
         {
             get
             {
-                var informational = typeof(Engine).Assembly
-                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+                var informational = typeof(Engine)
+                    .Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                    ?.InformationalVersion;
                 return informational.IsSet() ? StripBuildMetadata(informational) : Version;
             }
         }

--- a/projects/Hood.Core/Engine.cs
+++ b/projects/Hood.Core/Engine.cs
@@ -188,7 +188,15 @@ namespace Hood.Core
         }
 
         /// <summary>
-        /// Loads a Hood CMS resource, if BypassCDN is not set in appsettings.json, the resource will load from jsdelivr. Otherwise it will load from the given local path.
+        /// Resolves the URL for a Hood CMS asset, in this resolution order:
+        /// <list type="number">
+        /// <item><c>BypassCDN: true</c> — returns <paramref name="localPath"/> to serve from the app's own <c>wwwroot</c>.</item>
+        /// <item><c>CdnFullPath</c> set — returns <c>{CdnFullPath}{localPath}</c> verbatim; Hood appends no version, so the consumer owns the version pin (use for self-hosting, mirrors, or pinning a specific version).</item>
+        /// <item>Default — returns <c>{CdnPath}@{ResourceVersion}{localPath}</c>, with <see cref="ResourceVersion"/> carrying the prerelease tag so rc builds resolve on jsDelivr.</item>
+        /// </list>
+        /// Note: <c>asp-append-version</c> is a silent no-op on these CDN URLs — the tag helper can only hash local
+        /// <c>wwwroot</c> files, not remote CDN URLs, so it must not be relied on for cache-busting Hood resources.
+        /// Content-hashed cache-busting is deferred to the manifest pipeline (≥7.1, HOOD-109).
         /// </summary>
         public static string Resource(string localPath)
         {
@@ -196,7 +204,11 @@ namespace Hood.Core
             {
                 return localPath;
             }
-            return $"{CdnPath}@{Version}{localPath}";
+            if (CdnFullPath.IsSet())
+            {
+                return $"{CdnFullPath}{localPath}";
+            }
+            return $"{CdnPath}@{ResourceVersion}{localPath}";
         }
 
         public static string CdnPath
@@ -214,6 +226,30 @@ namespace Hood.Core
                 // during startup, and logging from inside the engine here would recurse.
                 catch (Exception) { }
                 return "https://cdn.jsdelivr.net/npm/hoodcms";
+            }
+        }
+
+        /// <summary>
+        /// Optional complete CDN base URL used verbatim by <see cref="Resource(string)"/> — Hood appends no
+        /// <c>@{version}</c> segment, so the consumer owns the version pin. Empty unless the consumer sets
+        /// <c>Hood:CdnFullPath</c>. Use for self-hosting/mirroring Hood assets or pinning a specific version
+        /// without overriding the <c>_Scripts</c>/<c>_Styles</c> views.
+        /// </summary>
+        public static string CdnFullPath
+        {
+            get
+            {
+                try
+                {
+                    if (Configuration.CdnFullPath.IsSet())
+                    {
+                        return Configuration.CdnFullPath;
+                    }
+                }
+                // ReSharper disable once EmptyGeneralCatchClause — config may be unavailable
+                // during startup, and logging from inside the engine here would recurse.
+                catch (Exception) { }
+                return null;
             }
         }
 
@@ -236,6 +272,39 @@ namespace Hood.Core
                 var version = typeof(Engine).Assembly.GetName().Version;
                 return $"{version.Major}.{version.Minor}.{version.Build}";
             }
+        }
+
+        /// <summary>
+        /// The version used to compose CDN asset URLs. Reads <c>AssemblyInformationalVersion</c> (truncated of
+        /// any <c>+build</c> metadata) so prerelease builds carry the <c>-rc.N</c> tag — without it, rc consumers
+        /// request <c>hoodcms@7.0.0</c> from jsDelivr while npm only has <c>7.0.0-rc.N</c>, 404-ing the admin UI.
+        /// Falls back to <see cref="Version"/> (<c>Major.Minor.Build</c>) if the informational version is absent.
+        /// Distinct from <see cref="Version"/>, which stays clean for footers, the <c>/version</c> endpoint and the
+        /// persisted <c>Hood.Version</c> DB marker.
+        /// </summary>
+        public static string ResourceVersion
+        {
+            get
+            {
+                var informational = typeof(Engine).Assembly
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+                return informational.IsSet() ? StripBuildMetadata(informational) : Version;
+            }
+        }
+
+        /// <summary>
+        /// Strips the <c>+{build}</c> metadata SemVer appends to an informational version, keeping any
+        /// <c>-rc.N</c> prerelease tag (e.g. <c>7.0.0-rc.24+abc123 → 7.0.0-rc.24</c>). Returns the input
+        /// unchanged when there is no build metadata.
+        /// </summary>
+        internal static string StripBuildMetadata(string informationalVersion)
+        {
+            if (!informationalVersion.IsSet())
+            {
+                return informationalVersion;
+            }
+            var plus = informationalVersion.IndexOf('+');
+            return plus >= 0 ? informationalVersion.Substring(0, plus) : informationalVersion;
         }
 
         public static string Url

--- a/projects/Hood.Core/HoodConfiguration.cs
+++ b/projects/Hood.Core/HoodConfiguration.cs
@@ -15,6 +15,7 @@ namespace Hood.Core
         public LogLevel LogLevel { get; set; }
         public bool BypassCDN { get; set; }
         public string CdnPath { get; set; }
+        public string CdnFullPath { get; set; }
         public Integrations Integrations { get; set; }
     }
 

--- a/projects/Hood.Tests/EngineResourceVersionTests.cs
+++ b/projects/Hood.Tests/EngineResourceVersionTests.cs
@@ -1,0 +1,33 @@
+using Hood.Core;
+using Xunit;
+
+namespace Hood.Tests
+{
+    /// <summary>
+    /// HOOD-90: CDN asset URLs must carry the prerelease tag. <see cref="Engine.ResourceVersion"/> reads
+    /// AssemblyInformationalVersion and strips the <c>+build</c> metadata while keeping any <c>-rc.N</c> tag,
+    /// so rc consumers request <c>hoodcms@7.0.0-rc.N</c> (which exists on npm) rather than <c>7.0.0</c> (404).
+    /// </summary>
+    public class EngineResourceVersionTests
+    {
+        [Theory]
+        [InlineData("7.0.0-rc.24+a6e2131958031874dbe85ef489b78d", "7.0.0-rc.24")] // prerelease + build metadata
+        [InlineData("7.0.0+a6e2131958031874dbe85ef489b78d", "7.0.0")]            // stable + build metadata
+        [InlineData("7.0.0-rc.24", "7.0.0-rc.24")]                               // prerelease, no metadata
+        [InlineData("7.0.0", "7.0.0")]                                           // stable, no metadata
+        [InlineData("", "")]                                                     // empty passthrough
+        [InlineData(null, null)]                                                 // null passthrough
+        public void StripBuildMetadata_DropsBuildKeepsPrereleaseTag(string input, string expected)
+        {
+            Assert.Equal(expected, Engine.StripBuildMetadata(input));
+        }
+
+        [Fact]
+        public void ResourceVersion_NeverCarriesBuildMetadata()
+        {
+            // Whatever the running assembly's informational version is, the CDN segment must never contain
+            // the '+{commit}' metadata (jsDelivr would 404 on it).
+            Assert.DoesNotContain("+", Engine.ResourceVersion);
+        }
+    }
+}

--- a/projects/Hood.Tests/EngineResourceVersionTests.cs
+++ b/projects/Hood.Tests/EngineResourceVersionTests.cs
@@ -12,11 +12,11 @@ namespace Hood.Tests
     {
         [Theory]
         [InlineData("7.0.0-rc.24+a6e2131958031874dbe85ef489b78d", "7.0.0-rc.24")] // prerelease + build metadata
-        [InlineData("7.0.0+a6e2131958031874dbe85ef489b78d", "7.0.0")]            // stable + build metadata
-        [InlineData("7.0.0-rc.24", "7.0.0-rc.24")]                               // prerelease, no metadata
-        [InlineData("7.0.0", "7.0.0")]                                           // stable, no metadata
-        [InlineData("", "")]                                                     // empty passthrough
-        [InlineData(null, null)]                                                 // null passthrough
+        [InlineData("7.0.0+a6e2131958031874dbe85ef489b78d", "7.0.0")] // stable + build metadata
+        [InlineData("7.0.0-rc.24", "7.0.0-rc.24")] // prerelease, no metadata
+        [InlineData("7.0.0", "7.0.0")] // stable, no metadata
+        [InlineData("", "")] // empty passthrough
+        [InlineData(null, null)] // null passthrough
         public void StripBuildMetadata_DropsBuildKeepsPrereleaseTag(string input, string expected)
         {
             Assert.Equal(expected, Engine.StripBuildMetadata(input));

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,8 @@ registerHoodTasks(require('gulp'), { less: true });
 
 Your tsconfigs `"extends": "hoodcms/tsconfig.base.json"` (declare your own `rootDir`/`outDir` — path options don't inherit across packages). The toolchain versions are published as **optional peer dependencies** — install the ones you use at Hood's audited versions.
 
+By default Hood serves its admin/UI assets from jsDelivr; you can serve them from your own `wwwroot` or a self-hosted CDN instead. See [CDN asset delivery](docs/configuration.md#cdn-asset-delivery).
+
 ## Database Installation/Update
 
 Hood's schema ships as plain, idempotent, forward-only SQL scripts. EF Core migrations are only
@@ -119,7 +121,8 @@ Hood is split into focused packages under `projects/`, each published as its own
 
 Documentation is a work in progress. The most useful references today:
 
+- [`docs/configuration.md`](docs/configuration.md) — consumer `appsettings.json` reference, including CDN asset delivery.
 - [`sql/README.md`](sql/README.md) — database schema, the `hood-schema` runner, upgrade tiers, and how to regenerate the SQL.
-- [`DOCKER.md`](DOCKER.md) — the containerised local dev rig (`docker compose up`).
+- [`docs/docker.md`](docs/docker.md) — the containerised local dev rig (`docker compose up`).
 
 Also, feel free to add your issues or pull requests to our GitHub — we always welcome contributions!


### PR DESCRIPTION
## Overview

`Engine.Resource()` composed CDN asset URLs as `{CdnPath}@{Version}{path}`, where `Engine.Version` reads the **assembly** version (`7.0.0`) and so drops the `-rc.N` prerelease tag. During the rc era that requested `hoodcms@7.0.0` from jsDelivr while npm only had `7.0.0-rc.N` → 404 → browsers nosniff-block Hood's admin CSS/JS. **Every rc-consuming app got a broken admin UI** until stable shipped.

Closes HOOD-90

---

## What Changed and Why

**`Engine.ResourceVersion` (new) — carries the prerelease tag.** Reads `AssemblyInformationalVersion`, truncated of `+build` metadata (keeps `-rc.N`), falling back to `Version` if absent. Used **only** in `Resource()`. `Engine.Version` is deliberately left untouched — it is load-bearing in the "Powered by" footers, the `/version` JSON endpoint, and the persisted `Hood.Version` DB marker; changing its format would mutate a stored value for no benefit.

**`HoodConfiguration.CdnFullPath` (new) — verbatim base-URL escape hatch.** `Resource()` previously appended `@{Version}` unconditionally, so a consumer could override the CDN *base* but never the version segment — which is why a prerelease consumer had to fork the `_Scripts`/`_Styles` views rather than fix it in config. When `CdnFullPath` is set it is used as-is (`{CdnFullPath}{localPath}`, no version appended), for self-hosting / mirrors / deliberate version pinning. Resolution order in `Resource()`: `BypassCDN` → `CdnFullPath` → `CdnPath`/default.

**Docs.** New `docs/configuration.md` consumer `appsettings.json` reference documenting the three CDN settings (linked from the readme), and a note that `asp-append-version` is a silent no-op on CDN URLs. Housekeeping: moved the root `DOCKER.md` into `docs/docker.md` and dropped the capitalised root filenames so the readme is the only root markdown.

---

## Tests

- `EngineResourceVersionTests` — `StripBuildMetadata` across 6 cases (prerelease+build, stable+build, prerelease-only, stable-only, empty, null) confirming `+build` is dropped and `-rc.N` retained.
- Invariant test: `ResourceVersion` never contains `+`.

---

## Breaking Changes

None. `Engine.Version` output is unchanged everywhere it is used; the new behaviour only affects the CDN URL the framework emits (now correct on rc builds). `CdnFullPath` is additive and optional.

---

## Testing Plan

- [ ] On an rc build, `/admin` loads CSS/JS from `…/hoodcms@7.0.0-rc.N/…` (no nosniff 404s).
- [ ] On a stable build, URLs resolve to `…@7.0.0/…` as before.
- [ ] Setting `Hood:CdnFullPath` serves assets verbatim from that base with no version segment appended.
- [ ] `Hood:BypassCDN: true` still serves from local `wwwroot`.
