### PR TITLE
HOOD-139 - Send real plain-text email part instead of the MailObject type name

### DIFF
--- a/projects/Hood.Core/Extensions/StringExtensions.cs
+++ b/projects/Hood.Core/Extensions/StringExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;
@@ -172,6 +173,74 @@ namespace Hood.Extensions
         {
             string encoded = HtmlEncoder.Default.Encode(content);
             return encoded;
+        }
+
+        /// <summary>
+        /// Converts an HTML fragment or document into a readable plain-text approximation, suitable for the
+        /// text/plain MIME alternative of an email. Drops script/style/head blocks, renders &lt;a href&gt; as
+        /// "label (url)", turns &lt;br&gt; and block-level closing tags into line breaks, strips the remaining
+        /// tags, decodes HTML entities and collapses runs of whitespace/blank lines.
+        /// </summary>
+        public static string HtmlToPlainText(this string html)
+        {
+            if (!html.IsSet())
+            {
+                return html;
+            }
+
+            string text = html;
+
+            // Remove non-content blocks entirely, including their inner text.
+            text = Regex.Replace(
+                text,
+                @"<(script|style|head)\b[^>]*>.*?</\1>",
+                " ",
+                RegexOptions.Singleline | RegexOptions.IgnoreCase
+            );
+
+            // Preserve links as "label (href)" so URLs survive the tag strip.
+            text = Regex.Replace(
+                text,
+                @"<a\b[^>]*?href\s*=\s*[""']([^""']*)[""'][^>]*>(.*?)</a>",
+                m =>
+                {
+                    string label = Regex.Replace(m.Groups[2].Value, "<[^>]+>", string.Empty).Trim();
+                    string href = m.Groups[1].Value.Trim();
+                    if (!label.IsSet())
+                        return href;
+                    return
+                        href.IsSet()
+                        && !string.Equals(label, href, StringComparison.OrdinalIgnoreCase)
+                        ? $"{label} ({href})"
+                        : label;
+                },
+                RegexOptions.Singleline | RegexOptions.IgnoreCase
+            );
+
+            // Line/section breaks from <br>, <hr> and block-level closing tags.
+            text = Regex.Replace(text, @"<br\s*/?>", "\n", RegexOptions.IgnoreCase);
+            text = Regex.Replace(
+                text,
+                @"<hr\s*/?>",
+                "\n--------------------\n",
+                RegexOptions.IgnoreCase
+            );
+            text = Regex.Replace(
+                text,
+                @"</(p|div|tr|li|h[1-6]|table|ul|ol|blockquote)>",
+                "\n",
+                RegexOptions.IgnoreCase
+            );
+
+            // Strip all remaining tags, then decode entities (&amp; &nbsp; …).
+            text = Regex.Replace(text, "<[^>]+>", string.Empty);
+            text = WebUtility.HtmlDecode(text);
+
+            // Collapse whitespace: single spaces inline, trim each line, cap blank-line runs.
+            text = Regex.Replace(text, @"[ \t]+", " ");
+            text = Regex.Replace(text, @" *\n *", "\n");
+            text = Regex.Replace(text, @"\n{3,}", "\n\n");
+            return text.Trim();
         }
 
         public static bool IsNullOrEmpty(this string str)

--- a/projects/Hood.Core/Models/Email/MailObject.cs
+++ b/projects/Hood.Core/Models/Email/MailObject.cs
@@ -133,6 +133,16 @@ namespace Hood.Models
             }
         }
 
+        /// <summary>
+        /// A plain-text rendering of the message — the builder-API <see cref="Text"/> body, or the
+        /// <see cref="Html"/> body converted to text. Never returns the type name, so it is safe even if a
+        /// caller passes the MailObject itself where a string is expected (HOOD-139).
+        /// </summary>
+        public override string ToString()
+        {
+            return Text.IsSet() ? Text : Html.HtmlToPlainText();
+        }
+
         public void AddCustomHtml(string htmlContent, string textContent)
         {
             if (textContent.IsSet())

--- a/projects/Hood.Core/Services/EmailSender/EmailSender.cs
+++ b/projects/Hood.Core/Services/EmailSender/EmailSender.cs
@@ -65,11 +65,16 @@ namespace Hood.Services
                 from = GetSiteFromEmail();
 
             var html = await _renderer.Render(message.Template, message);
+            // Build a real text/plain alternative. Builder-API emails already hold proper plain text in
+            // message.Text; template-rendered emails (empty Text) derive it from the rendered HTML. Never
+            // pass message.ToString() — it returns the type name and trips the MPART_ALT_DIFF spam heuristic
+            // (HOOD-139).
+            var plainText = message.Text.IsSet() ? message.Text : html.HtmlToPlainText();
             var msg = MailHelper.CreateSingleEmail(
                 from,
                 message.To,
                 message.Subject,
-                message.ToString(),
+                plainText,
                 html
             );
             msg.ReplyTo = replyTo;

--- a/projects/Hood.Tests/HtmlToPlainTextTests.cs
+++ b/projects/Hood.Tests/HtmlToPlainTextTests.cs
@@ -1,0 +1,75 @@
+using Hood.Extensions;
+using Xunit;
+
+namespace Hood.Tests
+{
+    /// <summary>
+    /// HOOD-139: emails must ship a real text/plain alternative instead of the C# type name. The text part is
+    /// derived from the rendered HTML via <see cref="StringExtensions.HtmlToPlainText"/> when a builder-API
+    /// MailObject.Text is not available — these cover that conversion.
+    /// </summary>
+    public class HtmlToPlainTextTests
+    {
+        [Fact]
+        public void StripsTagsAndKeepsTextContent()
+        {
+            var html = "<p>Hello <strong>world</strong></p>";
+            Assert.Equal("Hello world", html.HtmlToPlainText());
+        }
+
+        [Fact]
+        public void DecodesHtmlEntities()
+        {
+            Assert.Equal(
+                "Tom & Jerry — café",
+                "<p>Tom &amp; Jerry &mdash; caf&eacute;</p>".HtmlToPlainText()
+            );
+        }
+
+        [Fact]
+        public void RendersLinkAsLabelAndUrl()
+        {
+            var html = "<p>Visit <a href=\"https://hooddigital.com\">our site</a> today</p>";
+            Assert.Equal("Visit our site (https://hooddigital.com) today", html.HtmlToPlainText());
+        }
+
+        [Fact]
+        public void CollapsesLinkWhenLabelEqualsHref()
+        {
+            var html = "<a href=\"https://hooddigital.com\">https://hooddigital.com</a>";
+            Assert.Equal("https://hooddigital.com", html.HtmlToPlainText());
+        }
+
+        [Fact]
+        public void DropsStyleAndScriptBlocksEntirely()
+        {
+            var html =
+                "<head><style>p{color:red}</style></head><body><script>alert(1)</script><p>Body</p></body>";
+            Assert.Equal("Body", html.HtmlToPlainText());
+        }
+
+        [Fact]
+        public void BlockTagsAndBrBecomeNewlines()
+        {
+            var html = "<h1>Title</h1><p>Line one<br>Line two</p>";
+            Assert.Equal("Title\nLine one\nLine two", html.HtmlToPlainText());
+        }
+
+        [Fact]
+        public void OutputNeverContainsAngleBracketTags()
+        {
+            var html = "<div><table><tr><td><p>Cell <em>x</em></p></td></tr></table></div>";
+            var text = html.HtmlToPlainText();
+            Assert.DoesNotContain("<", text);
+            Assert.DoesNotContain(">", text);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void PassesThroughEmptyOrNull(string input)
+        {
+            Assert.Equal(input, input.HtmlToPlainText());
+        }
+    }
+}


### PR DESCRIPTION
## Overview

`EmailSender.SendEmailAsync(MailObject, …)` passed `message.ToString()` as the `text/plain` MIME alternative of **every** email. `MailObject` has no `ToString()` override, so `Object.ToString()` returned the literal string `Hood.Models.MailObject` — a garbage text part wildly mismatched from the HTML part, which trips the `MPART_ALT_DIFF` spam heuristic and degrades inbox placement for **all** Hood clients. Surfaced via a Gmail deliverability investigation.

Closes HOOD-139

---

## What Changed and Why

**`EmailSender` now sends a real plain-text body.** Builds the text part from `message.Text` (builder-API emails — `AddParagraph`/`AddCallToAction`/etc. already populate the `_textBody`), or, when that's empty (template-rendered emails), derives it from the rendered HTML via the new `HtmlToPlainText()`. Never passes `message.ToString()`.

**`string.HtmlToPlainText()` (new, `Hood.Extensions`).** Converts an HTML email to a readable text approximation: drops `script`/`style`/`head` blocks, renders `<a href>` as `label (url)`, turns `<br>`/block-closing tags into newlines, strips remaining tags, decodes HTML entities, collapses whitespace. No new dependency (HtmlAgilityPack not in the project).

**`MailObject.ToString()` override.** Returns the body text (`Text`, else `Html` converted), never the type name — defensive depth so the type name can't leak again even if a future caller mis-passes the object.

---

## Tests

- `HtmlToPlainTextTests` — 9 cases: tag stripping, entity decoding, link `label (url)` rendering, link collapse when label==href, script/style/head removal, block/`<br>` → newline, a no-angle-bracket-in-output invariant, and null/empty passthrough.

## Coverage note

`EmailSender` itself is not unit-tested — it requires SendGrid + a booted engine (the same seam limitation as the rest of the suite; `RecaptchaService` is testable via a fake client, `EmailSender` has no such seam). The logic-heavy, risky part (`HtmlToPlainText`) is fully covered. Final empirical check is QA (mail-tester / Gmail "show original"), per the issue.

---

## Breaking Changes

None. `MailObject.ToString()` previously returned the type name (never anything useful); callers relying on that string do not exist. The text/plain part of sent mail changes from the type name to real text.

---

## Testing Plan

- [ ] Send a builder-API email (e.g. account notification) → text part is the real message text, not `Hood.Models.MailObject`.
- [ ] Send a template-rendered email → text part is a readable rendering of the HTML.
- [ ] mail-tester no longer flags `MPART_ALT_DIFF`; HTML part unchanged.
