### PR TITLE
HOOD-125 - Redirect identity-less /account/ requests to login instead of 500

### DIFF
--- a/projects/Hood.Core/BaseControllers/AccountController.cs
+++ b/projects/Hood.Core/BaseControllers/AccountController.cs
@@ -29,11 +29,20 @@ namespace Hood.BaseControllers
 
         // #region Account Home
 
+        [Authorize]
         [HttpGet]
         [Route("account/")]
         public virtual async Task<IActionResult> Index(string returnUrl, bool created = false)
         {
-            var user = await GetCurrentUserOrThrow();
+            var user = await _account.GetUserByIdAsync(User.GetLocalUserId());
+            if (user?.UserProfile == null)
+            {
+                // Authenticated principal we can't resolve to a usable user (a stale or half-populated
+                // cookie, e.g. an empty email claim) — sign it out and redirect to login rather than throw.
+                var signInManager = Engine.Services.Resolve<SignInManager<ApplicationUser>>();
+                await signInManager.SignOutAsync();
+                return RedirectToAction(nameof(Login), new { returnUrl });
+            }
             var model = new ManageAccountViewModel
             {
                 LocalUserId = user.Id,
@@ -48,6 +57,7 @@ namespace Hood.BaseControllers
             return View(model);
         }
 
+        [Authorize]
         [HttpPost]
         [ValidateAntiForgeryToken]
         [Route("account/")]

--- a/projects/Hood.Core/Startup/IApplicationBuilderExtensions.cs
+++ b/projects/Hood.Core/Startup/IApplicationBuilderExtensions.cs
@@ -32,7 +32,15 @@ namespace Hood.Startup
             }
             else
             {
-                app.UseExceptionHandler("/error/500");
+                // AllowStatusCode404Response stops the handler escalating a 404 from the re-executed
+                // /error/500 path into an unhandled InvalidOperationException.
+                app.UseExceptionHandler(
+                    new ExceptionHandlerOptions
+                    {
+                        ExceptionHandlingPath = "/error/500",
+                        AllowStatusCode404Response = true,
+                    }
+                );
                 app.UseStatusCodePagesWithReExecute("/error/{0}");
             }
 

--- a/projects/Hood.Tests/HttpSmokeTests.cs
+++ b/projects/Hood.Tests/HttpSmokeTests.cs
@@ -20,9 +20,9 @@ namespace Hood.Tests
 {
     /// <summary>
     /// Boots the real Hood web app in-process via <see cref="WebApplicationFactory{TEntryPoint}"/>
-    /// against the test SQL database and drives HTTP smoke checks (HOOD-72): the anonymous login page
-    /// renders, and after a genuine cookie login the standard-Identity admin pages (the HOOD-66 role
-    /// views included) render without 500s.
+    /// against the test SQL database and drives HTTP smoke checks: the anonymous login page renders, and
+    /// after a genuine cookie login the standard-Identity admin pages (the role views included) render
+    /// without 500s.
     ///
     /// Engine initialisation already happens inside the host pipeline (ConfigureHood / UseHood), which
     /// WebApplicationFactory runs — so the WAF-hosted app behaves like the real one. The only piece
@@ -60,6 +60,28 @@ namespace Hood.Tests
             var resp = await client.GetAsync("/account/login");
 
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+
+        [SkippableFact]
+        public async Task Anonymous_account_index_redirects_to_login_not_500()
+        {
+            Skip.IfNot(_fx.Db.Available, _fx.Db.UnavailableReason);
+
+            using var client = NewClient();
+            var resp = await client.GetAsync("/account/");
+
+            // An identity-less request to /account/ must be bounced to login by the [Authorize] gate,
+            // never 500 via GetCurrentUserOrThrow.
+            Assert.True(
+                resp.StatusCode == HttpStatusCode.Redirect
+                    || resp.StatusCode == HttpStatusCode.Found,
+                $"GET /account/ anonymous expected a 302 to login but got {(int)resp.StatusCode} {resp.StatusCode}."
+            );
+            Assert.Contains(
+                "login",
+                resp.Headers.Location?.ToString() ?? "",
+                System.StringComparison.OrdinalIgnoreCase
+            );
         }
 
         [SkippableFact]

--- a/projects/Hood.Tests/HttpSmokeTests.cs
+++ b/projects/Hood.Tests/HttpSmokeTests.cs
@@ -80,7 +80,7 @@ namespace Hood.Tests
             Assert.Contains(
                 "login",
                 resp.Headers.Location?.ToString() ?? "",
-                System.StringComparison.OrdinalIgnoreCase
+                StringComparison.OrdinalIgnoreCase
             );
         }
 


### PR DESCRIPTION
## Overview

`AccountController.Index` (GET `/account/`) had no `[Authorize]` gate, so an unauthenticated — or authenticated-but-email-less — principal flowed straight into `GetCurrentUserOrThrow()`, which threw and produced a **500** instead of redirecting to login. The production exception handler then re-executed `/error/500`, whose 404 escalated into an unhandled `InvalidOperationException`. Both defects are in `Hood.Core` and affect every v7 consumer.

Closes HOOD-125

---

## What Changed and Why

**`[Authorize]` on both `Index` actions.** An unauthenticated request now returns a 302 to the configured login path instead of reaching `GetCurrentUserOrThrow`.

**Defensive user load on GET `Index`.** A principal that passes `[Authorize]` but can't be resolved to a usable user (a stale or half-populated cookie — e.g. an empty email claim) is now signed out and redirected to login, rather than throwing. `GetCurrentUserOrThrow` is left as-is for the genuinely-authenticated call sites.

**`AllowStatusCode404Response` on the exception handler.** `UseExceptionHandler` now uses the `ExceptionHandlerOptions` overload with `AllowStatusCode404Response = true`, so a 404 from the re-executed `/error/500` path no longer escalates into an unhandled `InvalidOperationException`.

---

## Tests

- `HttpSmokeTests.Anonymous_account_index_redirects_to_login_not_500` — anonymous `GET /account/` returns a 302 to login (not a 500), via the `WebApplicationFactory` harness.

---

## Breaking Changes

None. `/account/` was already intended to require authentication; it now enforces it correctly instead of 500-ing.

---

## Testing Plan

- [ ] Anonymous `GET /account/` → 302 to login.
- [ ] An authenticated principal with no email claim → signed out + 302 to login, no 500.
- [ ] A normal authenticated user → account page renders as before.
- [ ] A thrown exception renders the error page without an `InvalidOperationException`.
