### PR TITLE
HOOD-99 - Short-circuit empty recaptcha token before calling the assessment API

### DIFF
--- a/projects/Hood.Core/Services/RecaptchaService/RecaptchaService.cs
+++ b/projects/Hood.Core/Services/RecaptchaService/RecaptchaService.cs
@@ -67,12 +67,21 @@ namespace Hood.Services
                 }
 
                 string token = request.Form["g-recaptcha-response"];
+                if (string.IsNullOrWhiteSpace(token))
+                {
+                    await Log(
+                        "Recaptcha failed — no token submitted (check the site key is an Enterprise key valid for this domain).",
+                        LogType.Warning
+                    );
+                    return new RecaptchaResponse { Passed = false };
+                }
+
                 Assessment assessment = await _assessmentClient.CreateAssessmentAsync(
                     settings.GoogleRecaptchaProjectId,
                     settings.GoogleCloudApiKey,
                     new Event
                     {
-                        Token = token ?? string.Empty,
+                        Token = token,
                         SiteKey = settings.GoogleRecaptchaSiteKey,
                         ExpectedAction = expectedAction ?? string.Empty,
                     }


### PR DESCRIPTION
## Overview

When `enterprise.js` cannot obtain a token — typically because the configured site key is not authorised for the request domain — the hidden `g-recaptcha-response` field is left empty. Previously `RecaptchaService.Validate` passed that empty string straight to the Google assessment API, which returned an `InvalidArgument` error that surfaced as error-level log noise and a wasted API round-trip. This PR short-circuits that path.

## What changed and why

**`Hood.Core/Services/RecaptchaService/RecaptchaService.cs`**

Added a `string.IsNullOrWhiteSpace` guard immediately after reading `g-recaptcha-response`. When the token is absent or blank the service now logs a single `Warning` — with an actionable hint about the site key domain allowlist — and returns `Passed = false` without ever calling the assessment API. The outcome is identical to before (fail-closed), but the signal quality improves: one clear warning line instead of an `Error`-level exception from Google, and no unnecessary outbound call.

The `Token = token ?? string.Empty` fallback on the `Event` constructor is also removed — it is now unreachable (the guard above ensures `token` is non-null/non-empty before reaching that line).

## Tests

The existing `RecaptchaServiceTests` suite (49 tests) passes green. The new early-return path is covered by the suite's empty/null-token cases — confirmed with `dotnet test projects/Hood.Tests/Hood.Tests.csproj` (14 DB-gated tests skip cleanly without a DB, as expected).

## Breaking changes

None.

## Testing plan

- [ ] Stand up a site with a recaptcha-enabled form and a site key that is **not** authorised for the test domain.
- [ ] Submit the form — confirm the log shows a single `Warning: Recaptcha failed — no token submitted (check the site key is an Enterprise key valid for this domain).` and no `Error` entries.
- [ ] Confirm the form is rejected (`Passed = false`) and no call is made to the Google assessment API (check network traffic or API quota).
- [ ] With a correctly configured site key (domain authorised), confirm recaptcha still validates successfully end-to-end.