### PR TITLE
HOOD-91 - Fix dead gallery Add-files buttons by moving to the data-hood-media API

### DIFF
--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Content/_Editor_Media.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Content/_Editor_Media.cshtml
@@ -3,9 +3,11 @@
     <h5 class="mt-2 mb-0">Images &amp; Media</h5>
     <p>Add media files to this, select files by clicking 'Add files' below.</p>
     <div id="content-gallery-list" class="refresh mb-3" data-url="@Url.Action("Gallery", new { id = Model.Id })"></div>
-    <a class="btn btn-success text-white" 
-        media-gallery="content-gallery-list"
-        media-url="@Url.Action("UploadToGallery", new { id = Model.Id })">
+    <a class="btn btn-success text-white"
+        data-hood-media="gallery"
+        data-hood-media-list="@Url.Action("Action", "Media")"
+        data-hood-media-url="@Url.Action("UploadToGallery", new { id = Model.Id })"
+        data-hood-media-target="content-gallery-list">
         <i class="fa fa-plus-circle me-2"></i>
         <span>Add files...</span>
     </a>

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Floorplans.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Floorplans.cshtml
@@ -3,9 +3,11 @@
     <h5 class="mt-2 mb-0">Floor plans</h5>
     <p>You can add images or PDFs to this, images will appear in a floor plan view in the template, or can be templated to appear however you want.</p>
     <div id="property-floorplan-list" class="refresh mb-3" data-url="@Url.Action("Floorplans", new { id = Model.Id })"></div>
-    <a class="btn btn-success text-white" 
-        media-gallery="property-floorplan-list"
-        media-url="@Url.Action("UploadFloorplan", new { id = Model.Id })">
+    <a class="btn btn-success text-white"
+        data-hood-media="gallery"
+        data-hood-media-list="@Url.Action("Action", "Media")"
+        data-hood-media-url="@Url.Action("UploadFloorplan", new { id = Model.Id })"
+        data-hood-media-target="property-floorplan-list">
         <i class="fa fa-plus-circle me-2"></i>
         <span>Add files...</span>
     </a>

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Media.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Media.cshtml
@@ -3,9 +3,11 @@
     <h5 class="mt-2 mb-0">Images &amp; Media</h5>
     <p>Add media files to this, select files by clicking 'Add files' below.</p>
     <div id="property-gallery-list" class="refresh mb-3" data-url="@Url.Action("Gallery", new { id = Model.Id })"></div>
-    <a class="btn btn-success text-white" 
-        media-gallery="property-gallery-list"
-        media-url="@Url.Action("UploadToGallery", new { id = Model.Id })">
+    <a class="btn btn-success text-white"
+        data-hood-media="gallery"
+        data-hood-media-list="@Url.Action("Action", "Media")"
+        data-hood-media-url="@Url.Action("UploadToGallery", new { id = Model.Id })"
+        data-hood-media-target="property-gallery-list">
         <i class="fa fa-plus-circle me-2"></i>
         <span>Add files...</span>
     </a>


### PR DESCRIPTION
## Overview

The Add-files buttons in the Content and Property gallery editor views used a stale `media-gallery=` / `media-url=` attribute style that `MediaModal` never binds. Clicking did nothing. This wires them up to the `data-hood-media` attribute API that the modal actually listens on.

## What changed and why

- `Hood.UI.Admin/Areas/Admin/UI/Content/_Editor_Media.cshtml` — Add-files button: replaced `media-gallery` / `media-url` with `data-hood-media="gallery"`, `data-hood-media-list`, `data-hood-media-url`, `data-hood-media-target`.
- `Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Media.cshtml` — same fix for the property gallery.
- `Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Floorplans.cshtml` — same fix for the floor plans gallery (pointing to `UploadFloorplan`).

`MediaModal` binds on `[data-hood-media=gallery]` and reads `data-hood-media-list` (modal URL), `data-hood-media-url` (upload endpoint), and `data-hood-media-target` (DataList element id to reload after add). The stale attributes matched none of those selectors, so the modal never opened.

## Tests

No C# logic changed; only Razor view markup. Build passes clean (`dotnet build Hood.sln` — 0 warnings, 0 errors). CSharpier check clean.

## Breaking changes

None.

## Testing plan

- [ ] Open a Content item in the Admin, go to the Media tab — click "Add files..." and confirm the media modal opens.
- [ ] Select one or more media items and confirm they are added to the content gallery list.
- [ ] Open a Property listing in the Admin, go to the Media tab — click "Add files..." and confirm the modal opens and gallery reloads on add.
- [ ] On the same Property, go to the Floor Plans tab — click "Add files..." and confirm the modal opens and the floorplan list reloads on add.