### PR TITLE
HOOD-98 - Reject principal for a deleted user instead of NREing in OnValidatePrincipal

### DIFF
--- a/projects/Hood.Core/Startup/IServiceCollectionExtensions.cs
+++ b/projects/Hood.Core/Startup/IServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Hood.Extensions;
 using Hood.Identity;
 using Hood.Models;
 using Hood.Services;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
@@ -522,6 +523,12 @@ namespace Hood.Startup
                         // get the user profile and store important bits on the claim.
                         var repo = Engine.Services.Resolve<IPasswordAccountRepository>();
                         var user = await repo.GetUserByIdAsync(e.Principal.GetUserId());
+                        if (user?.UserProfile == null)
+                        {
+                            e.RejectPrincipal();
+                            await e.HttpContext.SignOutAsync();
+                            return;
+                        }
                         e.Principal.SetUserClaims(user.UserProfile);
                         if (user.EmailConfirmed)
                         {


### PR DESCRIPTION
## Overview

`OnValidatePrincipal` dereferenced the user record without a null check, so any request carrying a valid cookie for a deleted account (or one with a null `UserProfile`) threw an `NullReferenceException` on every request, making the session unusable until the cookie expired. This patch applies the standard ASP.NET Identity stale-principal pattern to sign the user out cleanly instead.

## What changed and why

**`projects/Hood.Core/Startup/IServiceCollectionExtensions.cs`**

- Added `using Microsoft.AspNetCore.Authentication;` — required for `HttpContext.SignOutAsync()`.
- In `ConfigurePasswordAuthentication`'s `OnValidatePrincipal` handler: immediately after fetching the user record, if `user` is `null` or `user.UserProfile` is `null`, call `e.RejectPrincipal()`, sign the cookie out, and return early — before any dereference.

## Tests

No automated test coverage for `OnValidatePrincipal` exists in the suite; the affected path requires a live Identity stack. The fix follows the documented ASP.NET `CookieAuthenticationEvents` pattern and the build + CSharpier checks pass clean.

## Breaking changes

None. The new code path only fires when a user no longer exists or has no profile — previously that path threw; now it cleans up the session instead.

## Testing plan

- [ ] Sign in as a user, then delete that user from the admin panel while the session is live.
- [ ] Make a subsequent request with the stale cookie — confirm a clean redirect to the login page rather than a 500.
- [ ] Sign in normally with a valid account — confirm the happy path is unaffected and claims are still set correctly.
- [ ] Check that a user with a null `UserProfile` (edge case) also gets signed out cleanly.