### PR TITLE
HOOD-138 - Harden DirectoryManager against root-dir NRE and stale cache

### DIFF
--- a/projects/Hood.Core/Services/DirectoryManager/DirectoryManager.cs
+++ b/projects/Hood.Core/Services/DirectoryManager/DirectoryManager.cs
@@ -87,7 +87,9 @@ namespace Hood.Services
             _topLevel = new Lazy<MediaDirectory[]>(() =>
                 _directoriesById
                     .Value.Values.Where(c =>
-                        c.Parent.Type == DirectoryType.User && c.OwnerId == userId
+                        c.ParentId != null
+                        && c.Parent.Type == DirectoryType.User
+                        && c.OwnerId == userId
                     )
                     .ToArray()
             );
@@ -104,6 +106,14 @@ namespace Hood.Services
 
         public IEnumerable<MediaDirectory> GetHierarchy(int id, int? stopAtId = null)
         {
+            // Reload the cache when the requested directory is absent — picks up
+            // directories created after the singleton was initialised without
+            // forcing a full DB round-trip on every call.
+            if (!_directoriesById.Value.ContainsKey(id))
+            {
+                ResetCache();
+            }
+
             List<MediaDirectory> result = new List<MediaDirectory>();
             MediaDirectory directory = GetDirectoryById(id);
             while (directory != null)


### PR DESCRIPTION
## Overview

`DirectoryManager` is a process-wide singleton. Two defects in the in-memory cache caused a NullReferenceException in `UserDirectories` for any installation with root directories, and made `GetHierarchy` / `GetPath` blind to directories created after process start.

## What changed and why

**Defect 1 — NRE in `UserDirectories`**

The LINQ-to-Objects predicate over `_directoriesById` called `c.Parent.Type` without checking whether `Parent` is null. Root/top-level directories always have `ParentId == null` and therefore a null `Parent` nav; the `.Where` scan touches every cached entry, so the method threw unconditionally whenever any root directory existed. Fixed by guarding with `c.ParentId != null` before accessing `c.Parent.Type`.

**Defect 2 — stale cache in `GetHierarchy`**

`_directoriesById` was populated once at construction and not refreshed unless callers explicitly invoked `ResetCache()`. Directories created after process start were invisible to `GetHierarchy`, producing wrong or empty paths for media uploads and breadcrumbs. The lowest-risk correct fix — chosen here — is a **targeted reload only when the requested id is absent from the cache**. This means warm-path calls (the vast majority) pay zero DB cost, while newly-created directories are found on their first access. The existing `ResetCache()` call in the mutation controllers already keeps the cache current for the common case; this is the safety net for any path that was missed.

## Tests

No automated test coverage for `DirectoryManager` exists in the test project today; the DB-gated tests skip cleanly without a DB. Manual verification steps are in the testing plan below.

## Breaking changes

None.

## Testing plan

- [ ] Seed a database with at least one root-level directory (no parent) and at least one user-owned nested directory
- [ ] Call `UserDirectories(userId)` — confirm it returns user directories without throwing
- [ ] Create a new directory via the admin UI, then upload a file to it — confirm the upload path is correct (i.e. `GetPath` reflects the new directory)
- [ ] Navigate breadcrumbs to the new directory — confirm they render correctly
- [ ] Confirm `TopLevel()`, `MediaDirectories()`, and `GetHierarchy` for pre-existing directories are unaffected