### PR TITLE
HOOD-84 - Give app.js/app.property.js a UMD globals map so externals resolve correctly

### DIFF
--- a/projects/Hood.Development/rollup.config.mjs
+++ b/projects/Hood.Development/rollup.config.mjs
@@ -9,9 +9,10 @@ export default hoodRollup({
         // bundled where used); the others take Hood's full base list.
         'app': {
             input: 'src/ts/app.ts',
-            externalsOverride: ['jQuery', 'bootstrap', 'sweetalert2', 'dropzone']
+            externalsOverride: ['jQuery', 'bootstrap', 'sweetalert2', 'dropzone'],
+            useHoodGlobals: true
         },
-        'app.property': 'src/ts/app.property.ts',
+        'app.property': { input: 'src/ts/app.property.ts', useHoodGlobals: true },
         'admin': { input: 'src/ts/admin.ts', useHoodGlobals: true },
         'login': { input: 'src/ts/login.ts', footer: '' }
     }


### PR DESCRIPTION
## Overview

Bind the `app` and `app.property` UMD bundles to Hood's canonical external globals via the build preset's `useHoodGlobals` flag, matching `admin` (which already had it). The substantive effect is on `sweetalert2`: these bundles previously resolved it to the lowercase `swal` global; this points them at the documented `Swal`.

Closes HOOD-84

## What changed and why

**`projects/Hood.Development/rollup.config.mjs`** — added `useHoodGlobals: true` to the `app` and `app.property` entries. The preset's `HOOD_GLOBALS` map then resolves `sweetalert2 → Swal` in the UMD output instead of Rollup's previous guess of `swal`.

**This is a correctness / future-proofing change, not a live-crash fix.** sweetalert2 currently ships `swal` as a lowercase alias of `Swal` (verified in the runtime CDN build `sweetalert2@10.13.0`, which assigns `Swal`, `swal` and `sweetAlert`, and in the v11 resolved in `node_modules`, which still defines `swal`). So the previous `e.swal` resolved fine and the bundles were not broken at runtime. `swal` is a **deprecated** alias, though — binding to the canonical `Swal` removes reliance on it so the bundles keep working if/when sweetalert2 drops it.

## Tests

- Built `app` / `app.property` / `admin` via `pnpm tsc-rollup-production` — no Rollup "missing global variable name" warning for `sweetalert2`.
- Diffed the built output: UMD global wiring changes `e.swal` → `e.Swal`; bundles are byte-identical otherwise (618,186 bytes for `app.js`).
- Loaded both built bundles against the live front-end deps (jQuery + `sweetalert2@10.13.0`): `window.hood` initialises and a `Swal` dialog fires. (The pre-change bundle also initialises, via the `swal` alias — confirming this is hardening, not a crash fix.)

## Breaking changes

None. Byte-identical output bar the global token; no public API change.

## Testing plan

- [ ] Build `projects/Hood.Development` (`pnpm tsc-rollup-production`) — no "missing global variable name" warning for `sweetalert2`.
- [ ] Load a front-end page (loads `app.js`; a property page loads `app.property.js`) and confirm `window.hood` is defined with no console error.
- [ ] `admin.js` output unchanged (it already had `useHoodGlobals: true`).
