### PR TITLE
HOOD-144 - Give toast notifications the correct per-severity icon

### DIFF
--- a/projects/Hood.Development/src/ts/core/Alerts.ts
+++ b/projects/Hood.Development/src/ts/core/Alerts.ts
@@ -47,11 +47,11 @@ export class Alerts {
     }
 
     static warning(message: string, title: string = null, hideAfter: number = null) {
-      
+
         $.toast({
             heading: title,
             text: message,
-            icon: 'error',
+            icon: 'warning',
             position: 'bottom-left',
             loader: false,
             bgColor: '#ef9007',
@@ -59,14 +59,14 @@ export class Alerts {
             hideAfter: hideAfter
         });
 
-    }       
+    }
 
     static message(message: string, title: string = null, hideAfter: number = null) {
-      
+
         $.toast({
             heading: title,
             text: message,
-            icon: 'error',
+            icon: 'info',
             position: 'bottom-left',
             loader: false,
             bgColor: '#222222',
@@ -74,14 +74,14 @@ export class Alerts {
             hideAfter: hideAfter
         });
 
-    }     
+    }
 
     static success(message: string, title: string = null, hideAfter: number = null) {
-      
+
         $.toast({
             heading: title,
             text: message,
-            icon: 'error',
+            icon: 'success',
             position: 'bottom-left',
             loader: false,
             bgColor: '#28a745',
@@ -89,7 +89,7 @@ export class Alerts {
             hideAfter: hideAfter
         });
 
-    }   
+    }
 
     static alert(message: string, title: string = null, icon: string = 'info', hideAfter: number = 10000) {
 


### PR DESCRIPTION
## Overview

All four toast severity methods (`error`, `warning`, `message`, `success`) were passing `icon: 'error'` to jquery-toast-plugin regardless of severity — only `bgColor` differed. This meant success, info, and warning toasts rendered the error icon, contradicting their colour and intent. Each method now passes the matching icon string.

## What changed and why

- `Alerts.warning` — `icon: 'error'` → `icon: 'warning'`
- `Alerts.message` — `icon: 'error'` → `icon: 'info'`
- `Alerts.success` — `icon: 'error'` → `icon: 'success'`
- `Alerts.error` — unchanged, already correct
- Trailing whitespace in the same methods cleaned up

## Tests

No automated tests cover toast rendering; the fix is a mechanical string correction with no logic change. Manual verification steps are in the testing plan below.

## Breaking changes

None.

## Testing plan

- [ ] Trigger a success toast and confirm the success (checkmark) icon appears
- [ ] Trigger a warning toast and confirm the warning icon appears
- [ ] Trigger an info/message toast and confirm the info icon appears
- [ ] Trigger an error toast and confirm it still shows the error icon
- [ ] Confirm icon and `bgColor` are visually consistent for each severity