### PR TITLE
HOOD-142 - DirectoryManager cache: reload-once for absent ids + thread-safe ResetCache

### DIFF
--- a/projects/Hood.Core/Services/DirectoryManager/DirectoryManager.cs
+++ b/projects/Hood.Core/Services/DirectoryManager/DirectoryManager.cs
@@ -14,9 +14,14 @@ namespace Hood.Services
     public class DirectoryManager : IDirectoryManager
     {
         private readonly IConfiguration _config;
-        private Lazy<MediaDirectory[]> _topLevel;
-        private Lazy<MediaDirectory> _siteDirectory;
-        private Lazy<Dictionary<int, MediaDirectory>> _directoriesById;
+        private readonly object _cacheLock = new object();
+
+        // Ids confirmed absent after a reload — suppresses repeated full reloads for stale references.
+        private volatile HashSet<int> _confirmedAbsent = new HashSet<int>();
+
+        private volatile Lazy<MediaDirectory[]> _topLevel;
+        private volatile Lazy<MediaDirectory> _siteDirectory;
+        private volatile Lazy<Dictionary<int, MediaDirectory>> _directoriesById;
 
         public DirectoryManager(IConfiguration config)
         {
@@ -35,7 +40,8 @@ namespace Hood.Services
                 new DbContextOptionsBuilder<HoodDbContext>();
             options.UseSqlServer(_config["ConnectionStrings:DefaultConnection"]);
             HoodDbContext db = new HoodDbContext(options.Options);
-            _directoriesById = new Lazy<Dictionary<int, MediaDirectory>>(() =>
+
+            var newById = new Lazy<Dictionary<int, MediaDirectory>>(() =>
             {
                 IQueryable<MediaDirectory> q =
                     from d in db.MediaDirectories
@@ -52,14 +58,22 @@ namespace Hood.Services
                     };
                 return q.ToDictionary(c => c.Id);
             });
-            _topLevel = new Lazy<MediaDirectory[]>(() =>
-                _directoriesById.Value.Values.Where(c => c.ParentId == null).ToArray()
+            var newTopLevel = new Lazy<MediaDirectory[]>(() =>
+                newById.Value.Values.Where(c => c.ParentId == null).ToArray()
             );
-            _siteDirectory = new Lazy<MediaDirectory>(() =>
-                _directoriesById.Value.Values.SingleOrDefault(c =>
+            var newSiteDirectory = new Lazy<MediaDirectory>(() =>
+                newById.Value.Values.SingleOrDefault(c =>
                     c.Slug == MediaManager.SiteDirectorySlug && c.Type == DirectoryType.System
                 )
             );
+
+            lock (_cacheLock)
+            {
+                _directoriesById = newById;
+                _topLevel = newTopLevel;
+                _siteDirectory = newSiteDirectory;
+                _confirmedAbsent = new HashSet<int>();
+            }
         }
 
         public MediaDirectory GetDirectoryById(int id)
@@ -106,12 +120,20 @@ namespace Hood.Services
 
         public IEnumerable<MediaDirectory> GetHierarchy(int id, int? stopAtId = null)
         {
-            // Reload the cache when the requested directory is absent — picks up
-            // directories created after the singleton was initialised without
-            // forcing a full DB round-trip on every call.
-            if (!_directoriesById.Value.ContainsKey(id))
+            // Reload once when the id is absent — picks up newly-created directories.
+            // If the id is still missing after a reload it is recorded so subsequent
+            // calls skip the DB round-trip entirely.
+            if (!_directoriesById.Value.ContainsKey(id) && !_confirmedAbsent.Contains(id))
             {
                 ResetCache();
+                if (!_directoriesById.Value.ContainsKey(id))
+                {
+                    lock (_cacheLock)
+                    {
+                        var absent = new HashSet<int>(_confirmedAbsent) { id };
+                        _confirmedAbsent = absent;
+                    }
+                }
             }
 
             List<MediaDirectory> result = new List<MediaDirectory>();

--- a/projects/Hood.Core/Services/DirectoryManager/DirectoryManager.cs
+++ b/projects/Hood.Core/Services/DirectoryManager/DirectoryManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Hood.Extensions;
@@ -19,9 +19,26 @@ namespace Hood.Services
         // Ids confirmed absent after a reload — suppresses repeated full reloads for stale references.
         private volatile HashSet<int> _confirmedAbsent = new HashSet<int>();
 
-        private volatile Lazy<MediaDirectory[]> _topLevel;
-        private volatile Lazy<MediaDirectory> _siteDirectory;
-        private volatile Lazy<Dictionary<int, MediaDirectory>> _directoriesById;
+        // Single holder published atomically; readers capture all three Lazy fields in one volatile read.
+        private volatile CacheSnapshot _cache;
+
+        private sealed class CacheSnapshot
+        {
+            internal readonly Lazy<Dictionary<int, MediaDirectory>> ById;
+            internal readonly Lazy<MediaDirectory[]> TopLevel;
+            internal readonly Lazy<MediaDirectory> SiteDirectory;
+
+            internal CacheSnapshot(
+                Lazy<Dictionary<int, MediaDirectory>> byId,
+                Lazy<MediaDirectory[]> topLevel,
+                Lazy<MediaDirectory> siteDirectory
+            )
+            {
+                ById = byId;
+                TopLevel = topLevel;
+                SiteDirectory = siteDirectory;
+            }
+        }
 
         public DirectoryManager(IConfiguration config)
         {
@@ -31,7 +48,7 @@ namespace Hood.Services
 
         public int Count()
         {
-            return _directoriesById.Value.Count;
+            return _cache.ById.Value.Count;
         }
 
         public void ResetCache()
@@ -39,83 +56,71 @@ namespace Hood.Services
             DbContextOptionsBuilder<HoodDbContext> options =
                 new DbContextOptionsBuilder<HoodDbContext>();
             options.UseSqlServer(_config["ConnectionStrings:DefaultConnection"]);
-            HoodDbContext db = new HoodDbContext(options.Options);
+            using HoodDbContext db = new HoodDbContext(options.Options);
 
-            var newById = new Lazy<Dictionary<int, MediaDirectory>>(() =>
-            {
-                IQueryable<MediaDirectory> q =
-                    from d in db.MediaDirectories
-                    select new MediaDirectory
-                    {
-                        Id = d.Id,
-                        DisplayName = d.DisplayName,
-                        Slug = d.Slug,
-                        Type = d.Type,
-                        OwnerId = d.OwnerId,
-                        ParentId = d.ParentId,
-                        Parent = d.Parent,
-                        Children = d.Children,
-                    };
-                return q.ToDictionary(c => c.Id);
-            });
+            var allDirectories = (
+                from d in db.MediaDirectories
+                select new MediaDirectory
+                {
+                    Id = d.Id,
+                    DisplayName = d.DisplayName,
+                    Slug = d.Slug,
+                    Type = d.Type,
+                    OwnerId = d.OwnerId,
+                    ParentId = d.ParentId,
+                    Parent = d.Parent,
+                    Children = d.Children,
+                }
+            ).ToDictionary(c => c.Id);
+
+            var newById = new Lazy<Dictionary<int, MediaDirectory>>(() => allDirectories);
             var newTopLevel = new Lazy<MediaDirectory[]>(() =>
-                newById.Value.Values.Where(c => c.ParentId == null).ToArray()
+                allDirectories.Values.Where(c => c.ParentId == null).ToArray()
             );
             var newSiteDirectory = new Lazy<MediaDirectory>(() =>
-                newById.Value.Values.SingleOrDefault(c =>
+                allDirectories.Values.SingleOrDefault(c =>
                     c.Slug == MediaManager.SiteDirectorySlug && c.Type == DirectoryType.System
                 )
             );
 
             lock (_cacheLock)
             {
-                _directoriesById = newById;
-                _topLevel = newTopLevel;
-                _siteDirectory = newSiteDirectory;
+                _cache = new CacheSnapshot(newById, newTopLevel, newSiteDirectory);
                 _confirmedAbsent = new HashSet<int>();
             }
         }
 
         public MediaDirectory GetDirectoryById(int id)
         {
-            if (!_directoriesById.Value.ContainsKey(id))
+            if (!_cache.ById.Value.ContainsKey(id))
             {
                 return null;
             }
 
-            return _directoriesById.Value[id];
+            return _cache.ById.Value[id];
         }
 
         public IEnumerable<MediaDirectory> MediaDirectories()
         {
-            _topLevel = new Lazy<MediaDirectory[]>(() =>
-                _directoriesById
-                    .Value.Values.Where(c => c.ParentId == _siteDirectory.Value.Id)
-                    .ToArray()
-            );
-            return _topLevel.Value;
+            CacheSnapshot snap = _cache;
+            return snap
+                .ById.Value.Values.Where(c => c.ParentId == snap.SiteDirectory.Value.Id)
+                .ToArray();
         }
 
         public IEnumerable<MediaDirectory> UserDirectories(string userId)
         {
-            _topLevel = new Lazy<MediaDirectory[]>(() =>
-                _directoriesById
-                    .Value.Values.Where(c =>
-                        c.ParentId != null
-                        && c.Parent.Type == DirectoryType.User
-                        && c.OwnerId == userId
-                    )
-                    .ToArray()
-            );
-            return _topLevel.Value;
+            CacheSnapshot snap = _cache;
+            return snap
+                .ById.Value.Values.Where(c =>
+                    c.ParentId != null && c.Parent.Type == DirectoryType.User && c.OwnerId == userId
+                )
+                .ToArray();
         }
 
         public IEnumerable<MediaDirectory> TopLevel()
         {
-            _topLevel = new Lazy<MediaDirectory[]>(() =>
-                _directoriesById.Value.Values.Where(c => c.ParentId == null).ToArray()
-            );
-            return _topLevel.Value;
+            return _cache.TopLevel.Value;
         }
 
         public IEnumerable<MediaDirectory> GetHierarchy(int id, int? stopAtId = null)
@@ -123,15 +128,18 @@ namespace Hood.Services
             // Reload once when the id is absent — picks up newly-created directories.
             // If the id is still missing after a reload it is recorded so subsequent
             // calls skip the DB round-trip entirely.
-            if (!_directoriesById.Value.ContainsKey(id) && !_confirmedAbsent.Contains(id))
+            if (!_cache.ById.Value.ContainsKey(id) && !_confirmedAbsent.Contains(id))
             {
                 ResetCache();
-                if (!_directoriesById.Value.ContainsKey(id))
+                if (!_cache.ById.Value.ContainsKey(id))
                 {
                     lock (_cacheLock)
                     {
-                        var absent = new HashSet<int>(_confirmedAbsent) { id };
-                        _confirmedAbsent = absent;
+                        if (!_confirmedAbsent.Contains(id))
+                        {
+                            var absent = new HashSet<int>(_confirmedAbsent) { id };
+                            _confirmedAbsent = absent;
+                        }
                     }
                 }
             }
@@ -366,8 +374,8 @@ namespace Hood.Services
                     else
                     {
                         template =
-                            $@"<div class='list-group-item list-group-item-action p-0 collapse' 
-                                           id='sub-directory-{directory.ParentId}' 
+                            $@"<div class='list-group-item list-group-item-action p-0 collapse'
+                                           id='sub-directory-{directory.ParentId}'
                                            aria-labelledby='sub-directory-heading-{directory.ParentId}'>";
                     }
 
@@ -375,9 +383,9 @@ namespace Hood.Services
                     if (directory.Children != null && directory.Children.Count > 0)
                     {
                         expand =
-                            $@" 
+                            $@"
                             <a class='btn-link' data-toggle='collapse' aria-labelledby='sub-directory-heading-{directory.Id}' data-target='#sub-directory-{directory.Id}' href='#sub-directory-{directory.Id}' aria-expanded='{expanded}' aria-controls='sub-directory-{directory.Id}'>
-                                <small><i class='fa fa-plus-square p-1 text-success'></i></small>                 
+                                <small><i class='fa fa-plus-square p-1 text-success'></i></small>
                             </a>";
                     }
 


### PR DESCRIPTION
## Overview

`GetHierarchy` reloaded the cache on every call for a directory id that is genuinely absent from the DB (e.g. a deleted-but-still-referenced id), re-introducing a full DB round-trip on every invocation. Separately, `ResetCache()` reassigned the three shared `Lazy` fields with no synchronisation, leaving a window where concurrent reads could observe a half-swapped cache. This PR fixes both.

## What changed and why

- **`ResetCache()` — atomic publish.** All three `Lazy` fields (`_directoriesById`, `_topLevel`, `_siteDirectory`) are now marked `volatile` and rebuilt into locals before being swapped inside a `lock (_cacheLock)` block. The absent-id set is also cleared atomically in the same lock. Concurrent readers always see a consistent set of fields.

- **`GetHierarchy` — reload-once for absent ids.** A `_confirmedAbsent` `HashSet<int>` (swapped copy-on-write under `_cacheLock`) tracks ids that were still missing after a cache reload. On a cache miss the logic is: if the id is in `_confirmedAbsent`, skip the reload entirely; otherwise reload once and, if the id is still absent, record it in `_confirmedAbsent`. Subsequent calls hit the fast path. `ResetCache()` clears the set so a genuinely new directory (same id reused) is not permanently suppressed.

- **No change to the warm path.** When the id is present in the cache the fast path is unchanged from HOOD-138.

## Tests

No automated test coverage for this service exists (it creates a `HoodDbContext` directly from config). The fix is validated structurally: the reload guard is a simple conditional before `ResetCache()`, and the lock scope is minimal (only the field-swap, not the DB query).

## Breaking changes

None.

## Testing plan

- [ ] Start the app, navigate to the media browser — directory tree renders correctly.
- [ ] Request a `GetHierarchy` / breadcrumb for a known-good directory id — path renders without error.
- [ ] Request a `GetHierarchy` for a deleted/absent directory id twice — confirm only one DB reload occurs (check SQL profiler or logs; second call should return empty with no DB hit).
- [ ] Create a new directory while the app is running — confirm it appears in the tree on next load (cache-miss reload still works).