### PR TITLE
HOOD-141 - Migrate single-image attach widgets to the data-hood-media API

### DIFF
--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Auth0Users/Edit.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Auth0Users/Edit.cshtml
@@ -115,24 +115,22 @@
                             <hr class="mt-4 mb-4" />
                             <div class="form-group row align-items-center g-3 mb-3">
                                 <div class="col-2">
-                                    <div style="background-image:url(@Model.Avatar.SmallUrl)" class="img img-full img-square rounded m-0 Avatar" id="users-feature-image"
-                                         media-attach="Avatar"
-                                         media-refresh=".Avatar"
-                                         media-url="@Url.Action("UploadMedia", "Users", new { id = Model.Id, field = nameof(Model.Avatar) })"></div>
+                                    <div style="background-image:url(@Model.Avatar.SmallUrl)" class="img img-full img-square rounded m-0 Avatar" id="users-feature-image"></div>
                                 </div>
                                 <div class="col">
                                     <h6>Avatar Image</h6>
                                     <p>Set an avatar for this user.</p>
                                     <a class="btn btn-success btn-sm"
-                                       media-attach="Avatar"
-                                       media-refresh=".Avatar"
-                                       media-url="@Url.Action("UploadMedia", "Users", new { id = Model.Id, field = nameof(Model.Avatar) })">
+                                       data-hood-media="attach"
+                                       data-hood-media-list="@Url.Action("Action", "Media")"
+                                       data-hood-media-url="@Url.Action("UploadMedia", "Users", new { id = Model.Id, field = nameof(Model.Avatar) })"
+                                       data-hood-media-refresh=".Avatar">
                                         Choose...
                                     </a>
                                     <a class="btn btn-danger btn-sm"
-                                       media-clear="Avatar"
-                                       media-refresh=".Avatar"
-                                       media-url="@Url.Action("RemoveMedia", "Users", new { id = Model.Id, field = nameof(Model.Avatar) })">
+                                       data-hood-media="clear"
+                                       href="@Url.Action("RemoveMedia", "Users", new { id = Model.Id, field = nameof(Model.Avatar) })"
+                                       data-hood-media-refresh=".Avatar">
                                         <i class="fa fa-trash"></i>
                                     </a>
                                 </div>

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Content/_Editor_Images.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Content/_Editor_Images.cshtml
@@ -5,25 +5,23 @@
 {
     <div class="form-group row align-items-center g-3 mb-3">
         <div class="col-2">
-            <div style="background-image:url(@Model.FeaturedImage.SmallUrl)" class="img img-full img-square rounded m-0 FeaturedImage" id="content-feature-image"
-                 media-attach="FeaturedImage"
-                 media-refresh=".FeaturedImage"
-                 media-url="@Url.Action("UploadMedia", "Content", new { id = Model.Id, field = nameof(Model.FeaturedImage) })"></div>
+            <div style="background-image:url(@Model.FeaturedImage.SmallUrl)" class="img img-full img-square rounded m-0 FeaturedImage" id="content-feature-image"></div>
         </div>
         <div class="col">
             <h6>Featured Image</h6>
             <p>Choose a featured image for this @Model.Type.TypeName. This will appear in content lists, and as the main featured image.</p>
             <a class="btn btn-success btn-sm"
-               media-attach="FeaturedImage"
-               media-refresh=".FeaturedImage"
-               media-url="@Url.Action("UploadMedia", "Content", new { id = Model.Id, field = nameof(Model.FeaturedImage) })">
+               data-hood-media="attach"
+               data-hood-media-list="@Url.Action("Action", "Media")"
+               data-hood-media-url="@Url.Action("UploadMedia", "Content", new { id = Model.Id, field = nameof(Model.FeaturedImage) })"
+               data-hood-media-refresh=".FeaturedImage">
                 Choose...
             </a>
             <a class="btn btn-danger btn-sm"
-                media-clear="FeaturedImage"
-                media-refresh=".FeaturedImage"
-                media-url="@Url.Action("RemoveMedia", "Content", new { id = Model.Id, field = nameof(Model.FeaturedImage) })">
-                <i class="fa fa-trash"></i>    
+               data-hood-media="clear"
+               href="@Url.Action("RemoveMedia", "Content", new { id = Model.Id, field = nameof(Model.FeaturedImage) })"
+               data-hood-media-refresh=".FeaturedImage">
+                <i class="fa fa-trash"></i>
             </a>
         </div>
     </div>
@@ -32,27 +30,25 @@
 {
     <div class="form-group row align-items-center g-3 mb-3">
         <div class="col-2">
-            <div style="background-image:url(@Model.ShareImage.SmallUrl)" class="img img-full img-square rounded m-0 ShareImage" id="content-share-image"
-                 media-attach="ShareImage"
-                 media-refresh=".ShareImage"
-                 media-url="@Url.Action("UploadMedia", "Content", new { id = Model.Id, field = nameof(Model.ShareImage) })"></div>
+            <div style="background-image:url(@Model.ShareImage.SmallUrl)" class="img img-full img-square rounded m-0 ShareImage" id="content-share-image"></div>
         </div>
         <div class="col">
             <h6>Sharer Image</h6>
             <p>Choose a sharer image for this @Model.Type.TypeName. This will appear when shared in social media, or in links, this will override the featured image if one is set.</p>
-             <a class="btn btn-success btn-sm"
-                 media-attach="ShareImage"
-                 media-refresh=".ShareImage"
-                 media-url="@Url.Action("UploadMedia", "Content", new { id = Model.Id, field = nameof(Model.ShareImage) })">
+            <a class="btn btn-success btn-sm"
+               data-hood-media="attach"
+               data-hood-media-list="@Url.Action("Action", "Media")"
+               data-hood-media-url="@Url.Action("UploadMedia", "Content", new { id = Model.Id, field = nameof(Model.ShareImage) })"
+               data-hood-media-refresh=".ShareImage">
                 Choose...
             </a>
             <a class="btn btn-danger btn-sm"
-                media-clear="ShareImage"
-                media-refresh=".ShareImage"
-                media-url="@Url.Action("RemoveMedia", "Content", new { id = Model.Id, field = nameof(Model.ShareImage) })">
-                <i class="fa fa-trash"></i>    
+               data-hood-media="clear"
+               href="@Url.Action("RemoveMedia", "Content", new { id = Model.Id, field = nameof(Model.ShareImage) })"
+               data-hood-media-refresh=".ShareImage">
+                <i class="fa fa-trash"></i>
             </a>
-       </div>
+        </div>
     </div>
 }
 @{

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Images.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Images.cshtml
@@ -3,48 +3,44 @@
 <p>Set images for this content. You can enable/disable these images for this content type in <a asp-action="Content" asp-controller="Settings">content settings</a>.</p>
 <div class="form-group row align-items-center g-3 mb-3">
     <div class="col-2">
-        <div style="background-image:url(@Model.FeaturedImage.Icon)" class="img img-full img-square rounded m-0 FeaturedImage" id="property-feature-image"
-             media-attach="FeaturedImage"
-             media-refresh=".FeaturedImage"
-             media-url="@Url.Action("UploadMedia", new { id = Model.Id, field = nameof(Model.FeaturedImage) })"></div>
+        <div style="background-image:url(@Model.FeaturedImage.Icon)" class="img img-full img-square rounded m-0 FeaturedImage" id="property-feature-image"></div>
     </div>
     <div class="col">
         <h6>Featured Image</h6>
         <p>Choose a featured image for this property. This will appear in content lists, and as the main featured image.</p>
         <a class="btn btn-success btn-sm"
-           media-attach="FeaturedImage"
-           media-refresh=".FeaturedImage"
-           media-url="@Url.Action("UploadMedia", new { id = Model.Id, field = nameof(Model.FeaturedImage) })">
+           data-hood-media="attach"
+           data-hood-media-list="@Url.Action("Action", "Media")"
+           data-hood-media-url="@Url.Action("UploadMedia", new { id = Model.Id, field = nameof(Model.FeaturedImage) })"
+           data-hood-media-refresh=".FeaturedImage">
             Choose...
         </a>
         <a class="btn btn-danger btn-sm"
-           media-clear="FeaturedImage"
-           media-refresh=".FeaturedImage"
-           media-url="@Url.Action("RemoveMedia", new { id = Model.Id, field = nameof(Model.FeaturedImage) })">
+           data-hood-media="clear"
+           href="@Url.Action("RemoveMedia", new { id = Model.Id, field = nameof(Model.FeaturedImage) })"
+           data-hood-media-refresh=".FeaturedImage">
             <i class="fa fa-trash"></i>
         </a>
     </div>
 </div>
 <div class="form-group row align-items-center g-3 mb-3">
     <div class="col-2">
-        <div style="background-image:url(@Model.InfoDownload.Icon)" class="img img-full img-square rounded m-0 InfoDownload" id="property-info-download"
-             media-attach="InfoDownload"
-             media-refresh=".InfoDownload"
-             media-url="@Url.Action("UploadMedia", new { id = Model.Id, field = nameof(Model.InfoDownload) })"></div>
+        <div style="background-image:url(@Model.InfoDownload.Icon)" class="img img-full img-square rounded m-0 InfoDownload" id="property-info-download"></div>
     </div>
     <div class="col">
         <h6>Info Pack PDF / Document</h6>
         <p>Add a PDF downloadable information pack for this property listing.</p>
         <a class="btn btn-success btn-sm"
-           media-attach="InfoDownload"
-           media-refresh=".InfoDownload"
-           media-url="@Url.Action("UploadMedia", new { id = Model.Id, field = nameof(Model.InfoDownload) })">
+           data-hood-media="attach"
+           data-hood-media-list="@Url.Action("Action", "Media")"
+           data-hood-media-url="@Url.Action("UploadMedia", new { id = Model.Id, field = nameof(Model.InfoDownload) })"
+           data-hood-media-refresh=".InfoDownload">
             Choose...
         </a>
         <a class="btn btn-danger btn-sm"
-           media-clear="InfoDownload"
-           media-refresh=".InfoDownload"
-           media-url="@Url.Action("RemoveMedia", new { id = Model.Id, field = nameof(Model.InfoDownload) })">
+           data-hood-media="clear"
+           href="@Url.Action("RemoveMedia", new { id = Model.Id, field = nameof(Model.InfoDownload) })"
+           data-hood-media-refresh=".InfoDownload">
             <i class="fa fa-trash"></i>
         </a>
     </div>

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Users/Edit.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Users/Edit.cshtml
@@ -115,24 +115,22 @@
                             <hr class="mt-4 mb-4" />
                             <div class="form-group row align-items-center g-3 mb-3">
                                 <div class="col-2">
-                                    <div style="background-image:url(@Model.Avatar.SmallUrl)" class="img img-full img-square rounded m-0 Avatar" id="users-feature-image"
-                                         media-attach="Avatar"
-                                         media-refresh=".Avatar"
-                                         media-url="@Url.Action("UploadMedia", "Users", new { id = Model.Id, field = nameof(Model.Avatar) })"></div>
+                                    <div style="background-image:url(@Model.Avatar.SmallUrl)" class="img img-full img-square rounded m-0 Avatar" id="users-feature-image"></div>
                                 </div>
                                 <div class="col">
                                     <h6>Avatar Image</h6>
                                     <p>Set an avatar for this user.</p>
                                     <a class="btn btn-success btn-sm"
-                                       media-attach="Avatar"
-                                       media-refresh=".Avatar"
-                                       media-url="@Url.Action("UploadMedia", "Users", new { id = Model.Id, field = nameof(Model.Avatar) })">
+                                       data-hood-media="attach"
+                                       data-hood-media-list="@Url.Action("Action", "Media")"
+                                       data-hood-media-url="@Url.Action("UploadMedia", "Users", new { id = Model.Id, field = nameof(Model.Avatar) })"
+                                       data-hood-media-refresh=".Avatar">
                                         Choose...
                                     </a>
                                     <a class="btn btn-danger btn-sm"
-                                       media-clear="Avatar"
-                                       media-refresh=".Avatar"
-                                       media-url="@Url.Action("RemoveMedia", "Users", new { id = Model.Id, field = nameof(Model.Avatar) })">
+                                       data-hood-media="clear"
+                                       href="@Url.Action("RemoveMedia", "Users", new { id = Model.Id, field = nameof(Model.Avatar) })"
+                                       data-hood-media-refresh=".Avatar">
                                         <i class="fa fa-trash"></i>
                                     </a>
                                 </div>


### PR DESCRIPTION
## Overview

Single-image pickers in the Content, Property, and Users/Auth0Users admin editors were using the unbound `media-url=` / `media-attach=` attribute style. `MediaModal` in `Media.ts` only binds `[data-hood-media=attach|select|gallery|clear]`, so those buttons were dead — the same symptom the gallery editors had before being fixed. This migrates all four affected views to the `data-hood-media` API.

## What changed and why

- `Hood.UI.Admin/Areas/Admin/UI/Content/_Editor_Images.cshtml` — FeaturedImage and ShareImage attach/clear buttons migrated to `data-hood-media=attach` / `data-hood-media=clear`; unbound attributes removed from the image preview `div`.
- `Hood.UI.Admin/Areas/Admin/UI/Property/_Editor_Images.cshtml` — FeaturedImage and InfoDownload pickers migrated; unbound attributes removed from preview `div`s.
- `Hood.UI.Admin/Areas/Admin/UI/Users/Edit.cshtml` — Avatar picker migrated.
- `Hood.UI.Admin/Areas/Admin/UI/Auth0Users/Edit.cshtml` — Avatar picker migrated.

Each attach button now carries `data-hood-media="attach"`, `data-hood-media-list` (the Media modal action URL), `data-hood-media-url` (the server-side attach endpoint), and `data-hood-media-refresh` (CSS class selector for the preview element). Each clear button carries `data-hood-media="clear"`, `href` (the remove endpoint read by `MediaModal.clear()`), and `data-hood-media-refresh`.

## Tests

No automated test coverage for admin Razor views. Build is clean, CSharpier check passes.

## Breaking changes

None.

## Testing plan

- [ ] Open a Content item editor → Images tab; confirm "Choose…" opens the media modal and the selected image updates the preview.
- [ ] Confirm the trash button prompts for confirmation and clears the image preview on success.
- [ ] Repeat for the Share Image picker on the same view.
- [ ] Open a Property listing editor → Images tab; confirm Featured Image and Info Pack pickers both open the modal and write back.
- [ ] Open a User edit page; confirm the Avatar picker opens the modal and updates the avatar preview.
- [ ] Open an Auth0 User edit page; confirm the same for the Avatar picker.