### PR TITLE
HOOD-101 - Implement the admin StatsAsync endpoint so the dashboard widget renders

### DIFF
--- a/projects/Hood.Core/BaseControllers/Admin/HomeController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/HomeController.cs
@@ -32,9 +32,9 @@ namespace Hood.Admin.BaseControllers
                 : auth0Account != null ? await auth0Account.GetStatisticsAsync()
                 : null;
 
-            PropertyStatistics properties = await HttpContext
-                .RequestServices.GetService<IPropertyRepository>()
-                ?.GetStatisticsAsync();
+            var propertyRepo = HttpContext.RequestServices.GetService<IPropertyRepository>();
+            PropertyStatistics properties =
+                propertyRepo != null ? await propertyRepo.GetStatisticsAsync() : null;
 
             return Json(new Statistics(content, users, properties));
         }

--- a/projects/Hood.Core/BaseControllers/Admin/HomeController.cs
+++ b/projects/Hood.Core/BaseControllers/Admin/HomeController.cs
@@ -1,7 +1,9 @@
-﻿using Hood.BaseControllers;
+﻿using System.Threading.Tasks;
+using Hood.BaseControllers;
 using Hood.Models;
 using Hood.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Hood.Admin.BaseControllers
 {
@@ -13,14 +15,29 @@ namespace Hood.Admin.BaseControllers
             return View();
         }
 
-        // [Route("admin/stats/")]
-        // public virtual async Task<IActionResult> StatsAsync()
-        // {
-        //     //ContentStatitsics content = new ContentStatitsics();
-        //     //UserStatistics users = await _account.GetStatisticsAsync();
-        //     //PropertyStatistics properties = await _property.GetStatisticsAsync();
-        //     return Json(new Statistics(content, users, properties));
-        // }
+        [Route("admin/stats/")]
+        public virtual async Task<IActionResult> StatsAsync()
+        {
+            var content = await HttpContext
+                .RequestServices.GetRequiredService<IContentRepository>()
+                .GetStatisticsAsync();
+
+            IPasswordAccountRepository passwordAccount =
+                HttpContext.RequestServices.GetService<IPasswordAccountRepository>();
+            IAuth0AccountRepository auth0Account =
+                HttpContext.RequestServices.GetService<IAuth0AccountRepository>();
+
+            UserStatistics users =
+                passwordAccount != null ? await passwordAccount.GetStatisticsAsync()
+                : auth0Account != null ? await auth0Account.GetStatisticsAsync()
+                : null;
+
+            PropertyStatistics properties = await HttpContext
+                .RequestServices.GetService<IPropertyRepository>()
+                ?.GetStatisticsAsync();
+
+            return Json(new Statistics(content, users, properties));
+        }
     }
 
     public class Statistics


### PR DESCRIPTION
## Overview

The admin dashboard JavaScript fires `$.get('/admin/stats/')` on every admin home load, but the matching action was commented out — producing a 404 on every request and leaving the stats widget permanently empty. This PR restores the `StatsAsync` action so the widget populates as intended.

## What changed and why

- **`projects/Hood.Core/BaseControllers/Admin/HomeController.cs`** — Restored `[Route("admin/stats/")] StatsAsync()`. The action resolves `IContentRepository`, `IPropertyRepository`, and the active account repository (`IPasswordAccountRepository` with `IAuth0AccountRepository` as fallback) from `HttpContext.RequestServices`, calls `GetStatisticsAsync()` on each, and returns the `Statistics` JSON the dashboard JS expects. Property service resolution is null-safe — consumers without the property module registered will receive `null` for that field rather than an error.

## Tests

No unit tests exist for this controller action. The build is clean (zero warnings). The fix can be verified manually: load any admin home page and confirm no 404 XHR appears in the browser network tab, and that the stats widget displays data.

## Breaking changes

None.

## Testing plan

- [ ] Run a Hood 7 consumer app and sign in as an admin
- [ ] Navigate to the admin dashboard (`/admin/`)
- [ ] Open browser DevTools → Network tab
- [ ] Confirm `GET /admin/stats/` returns 200 (not 404)
- [ ] Confirm the stats widget on the admin home page renders with data
- [ ] Confirm no console errors related to the stats request