### PR TITLE
HOOD-106 - Add SRI integrity hashes to admin/Core third-party CDN assets

### DIFF
--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Shared/_Scripts.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Shared/_Scripts.cshtml
@@ -1,8 +1,9 @@
 @{
 }
+@* Regenerate integrity hash after a vendor version bump: curl -sL "<url>" | openssl dgst -sha384 -binary | openssl base64 -A *@
 <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/hugerte@1/hugerte.min.js" referrerpolicy="origin"></script>
+<script src="https://cdn.jsdelivr.net/npm/hugerte@1.0.11/hugerte.min.js" integrity="sha384-dPcdOMqs031mv3Y8m6zNgx3EVTkJm/4w4prPDUatksHtbfv6FvbbFbEqVzFhEYoU" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.7.2/min/dropzone.min.js" integrity="sha512-9WciDs0XP20sojTJ9E7mChDXy6pcO0qHpwbEJID1YVavz2H6QBz5eLoDD8lseZOb2yGT8xDNIV7HIe1ZbuiDWg==" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@10.13.0/dist/sweetalert2.all.min.js" integrity="sha256-J9avsZWTdcAPp1YASuhlEH42nySYLmm0Jw1txwkuqQw=" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.min.js" integrity="sha512-d9xgZrVZpmmQlfonhQUvTR7lMPtO7NkZMkA0ABN3PHCbKA5nqylQ/yWlFAyY6hYgdF1Qh6nYiuADWwKB4C2WSw==" crossorigin="anonymous"></script>

--- a/projects/Hood.UI.Admin/Areas/Admin/UI/Shared/_Styles.cshtml
+++ b/projects/Hood.UI.Admin/Areas/Admin/UI/Shared/_Styles.cshtml
@@ -1,5 +1,5 @@
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@simonwep/pickr/dist/themes/monolith.min.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" integrity="sha384-KA6wR/X5RY4zFAHpv/CnoG2UW1uogYfdnP67Uv7eULvTveboZJg0qUpmJZb5VqzN" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@simonwep/pickr@1.8.1/dist/themes/monolith.min.css" integrity="sha384-j2z77wNufw8JmH+5FAIvmHcftvgUNffvVwD86d+2oeQTYKE4yqZDjjisHkc1mvYg" crossorigin="anonymous" />
 
 <environment exclude="Production">
     <link rel="stylesheet" href="@Engine.Resource("/src/css/admin.css")" asp-append-version="true">

--- a/projects/Hood.UI.Core/BaseUI/Install/Initialized.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Install/Initialized.cshtml
@@ -10,7 +10,7 @@
     <title>@ViewData["Title"]</title>
     <!-- The host restarts after setup; reload into the now-installed site shortly. -->
     <meta http-equiv="refresh" content="8; url=/" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" integrity="sha384-KA6wR/X5RY4zFAHpv/CnoG2UW1uogYfdnP67Uv7eULvTveboZJg0qUpmJZb5VqzN" crossorigin="anonymous" />
 
     <environment exclude="Production">
         <link rel="stylesheet" href="@Engine.Resource("/src/css/install.css")" asp-append-version="true">

--- a/projects/Hood.UI.Core/BaseUI/Install/Install.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Install/Install.cshtml
@@ -9,7 +9,7 @@
 
 <head>
     <title>@ViewData["Title"]</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" integrity="sha384-KA6wR/X5RY4zFAHpv/CnoG2UW1uogYfdnP67Uv7eULvTveboZJg0qUpmJZb5VqzN" crossorigin="anonymous" />
 
     <environment exclude="Production">
         <link rel="stylesheet" href="@Engine.Resource("/src/css/install.css")" asp-append-version="true">

--- a/projects/Hood.UI.Core/BaseUI/Shared/_Styles.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Shared/_Styles.cshtml
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" integrity="sha384-KA6wR/X5RY4zFAHpv/CnoG2UW1uogYfdnP67Uv7eULvTveboZJg0qUpmJZb5VqzN" crossorigin="anonymous" />
 <environment exclude="Production">
     <link rel="stylesheet" href="@Engine.Resource("/src/css/app.css")" asp-append-version="true">
 </environment>

--- a/projects/Hood.UI.Core/BaseUI/Shared/_Styles_Login.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Shared/_Styles_Login.cshtml
@@ -1,5 +1,5 @@
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" />
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@simonwep/pickr/dist/themes/monolith.min.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" integrity="sha384-KA6wR/X5RY4zFAHpv/CnoG2UW1uogYfdnP67Uv7eULvTveboZJg0qUpmJZb5VqzN" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@simonwep/pickr@1.8.1/dist/themes/monolith.min.css" integrity="sha384-j2z77wNufw8JmH+5FAIvmHcftvgUNffvVwD86d+2oeQTYKE4yqZDjjisHkc1mvYg" crossorigin="anonymous" />
 <environment exclude="Production">
     <link rel="stylesheet" href="@Engine.Resource("/src/css/login.css")" asp-append-version="true">
 </environment>


### PR DESCRIPTION
## Overview

Adds `integrity="sha384-…"` and `crossorigin="anonymous"` to every third-party CDN `<script>`/`<link>` tag in Hood.UI.Admin and Hood.UI.Core that was missing SRI. A compromised CDN entry would otherwise execute arbitrary script in the authenticated admin context with no browser-level detection.

## What changed and why

All hashes were computed against the pinned vendor file via `curl -sL "<url>" | openssl dgst -sha384 -binary | openssl base64 -A` and verified to match the served bytes.

Assets updated:

| Asset | File(s) |
|---|---|
| FontAwesome 5.11.2 `all.min.css` | Admin `_Styles.cshtml`, Core `_Styles.cshtml`, `_Styles_Login.cshtml`, `Install/Install.cshtml`, `Install/Initialized.cshtml` |
| Pickr 1.8.1 `monolith.min.css` (also pinned from floating `@simonwep/pickr` to `@1.8.1`) | Admin `_Styles.cshtml`, Core `_Styles_Login.cshtml` |
| HugeRTE `hugerte.min.js` (pinned from floating `@1` to `@1.0.11`) | Admin `_Scripts.cshtml` |

A one-line regeneration instruction is added as a Razor comment at the top of Admin `_Scripts.cshtml`.

Scope: Hood.UI.Admin and Hood.UI.Core only. Bootstrap3/4 RCLs are not touched (addressed under HOOD-107).

## Tests

- `dotnet build Hood.sln` — 0 warnings, 0 errors
- `dotnet csharpier check .` — clean

## Breaking changes

None.

## Testing plan

- [ ] Load the admin UI in a browser with DevTools open — no console SRI failures
- [ ] Load the install/initialized pages — no SRI failures
- [ ] Load a Core front-end page — no SRI failures on FA or Pickr stylesheet