### PR TITLE
HOOD-100 - Minimise required consumer settings — default Hood/Identity config, SuperAdminEmail from install

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,12 +23,11 @@ is the working example: it only sets the handful of values that genuinely differ
 defaults (its local connection string, a couple of password-policy overrides, and `BypassCDN` for
 the in-repo dev loop).
 
-## The site owner (`SuperAdminEmail`)
+## The site owner
 
-The site owner's email comes from the account you create on first run at `/install` — that's the
-source of truth, persisted to the database. `Hood:SuperAdminEmail` in configuration is an
-**optional override** for cases where you need to pin it outside the database; leave it unset and
-Hood uses whoever was installed.
+The site owner is simply the account you create on first run at `/install` — there is no
+configuration key for it. If you're upgrading a consumer that used to set `Hood:SuperAdminEmail`,
+remove it from `appsettings.json`; the key is no longer read and no other action is needed.
 
 ## Identity
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,60 @@
 # Hood configuration (`appsettings.json`)
 
-Reference for the `Hood` configuration section a consumer app provides. Only settings you need to
-override have to be present; sensible defaults apply otherwise.
+Reference for the `Hood` and `Identity` configuration sections a consumer app provides. Only
+settings you need to override have to be present; sensible defaults apply otherwise.
+
+## Minimal consumer `appsettings.json`
+
+The only setting every consumer must provide is the connection string. Everything else in this
+document is an optional override — a fresh site can start from:
+
+```jsonc
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=…;Database=…;User Id=…;Password=…;TrustServerCertificate=True"
+  }
+}
+```
+
+Add your own provider/integration keys (SendGrid, Google, Auth0, …) as you turn features on —
+most of those live in the admin **Settings** area (persisted to the database), not
+`appsettings.json`. [`Hood.Development/appsettings.json`](../projects/Hood.Development/appsettings.json)
+is the working example: it only sets the handful of values that genuinely differ from Hood's
+defaults (its local connection string, a couple of password-policy overrides, and `BypassCDN` for
+the in-repo dev loop).
+
+## The site owner (`SuperAdminEmail`)
+
+The site owner's email comes from the account you create on first run at `/install` — that's the
+source of truth, persisted to the database. `Hood:SuperAdminEmail` in configuration is an
+**optional override** for cases where you need to pin it outside the database; leave it unset and
+Hood uses whoever was installed.
+
+## Identity
+
+The whole `Identity` section is optional. Every setting below has a working default; only add a
+key when you need something other than Hood's default.
+
+| Setting | Default | Notes |
+|---|---|---|
+| `Identity:Password:RequireDigit` | `true` | |
+| `Identity:Password:RequireLowercase` | `false` | |
+| `Identity:Password:RequireUppercase` | `false` | |
+| `Identity:Password:RequireNonAlphanumeric` | `true` | |
+| `Identity:Password:RequiredLength` | `6` | |
+| `Identity:Cookies:Name` | `hoodcms` | Prefixed onto the auth/antiforgery/session/consent cookie names. |
+| `Identity:Cookies:Domain` | *(unset)* | Cookie domain; unset scopes cookies to the current host. |
+| `Identity:Cookies:ConsentRequired` | `true` | Whether the cookie-consent banner gates non-essential cookies. |
+| `Identity:LoginPath` | `/account/login` | |
+| `Identity:LogoutPath` | `/account/logout` | |
+| `Identity:AccessDeniedPath` | `/account/access-denied` | |
+
+### Auth0 (optional)
+
+`Identity:Auth0` is entirely optional. Leave it out (or leave `Domain`/`ClientId` unset) and Hood
+runs on the standard ASP.NET Identity/password backend — no Auth0 configuration is required to run
+Hood at all. Set both `Identity:Auth0:Domain` and `Identity:Auth0:ClientId` to switch the site to
+the Auth0 backend instead.
 
 ## CDN asset delivery
 

--- a/projects/Hood.Core/BaseControllers/InstallController.cs
+++ b/projects/Hood.Core/BaseControllers/InstallController.cs
@@ -29,7 +29,7 @@ namespace Hood.BaseControllers
             {
                 return RedirectToAction("Index", "Home");
             }
-            return View(new InstallModel { Email = Engine.Configuration?.SuperAdminEmail });
+            return View(new InstallModel());
         }
 
         /// <summary>
@@ -54,13 +54,6 @@ namespace Hood.BaseControllers
 
             try
             {
-                // The chosen administrator email becomes the site owner for this initialisation run,
-                // so the seed's GetSiteAdmin resolves to the account we are about to create.
-                if (Engine.Configuration != null)
-                {
-                    Engine.Configuration.SuperAdminEmail = model.Email;
-                }
-
                 IPasswordAccountRepository accounts =
                     Engine.Services.Resolve<IPasswordAccountRepository>();
 
@@ -119,9 +112,10 @@ namespace Hood.BaseControllers
                 await accounts.AddUserToRolesAsync(admin, ownerRoles.ToArray());
 
                 // Seed Hood: version stamp, site owner option, media directories, default settings.
+                // The form's email is the only input — it becomes the site owner via GetSiteAdmin.
                 HoodDbContext hoodDb = Engine.Services.Resolve<HoodDbContext>();
                 IdentityContext identity = Engine.Services.Resolve<IdentityContext>();
-                await hoodDb.Seed(identity);
+                await hoodDb.Seed(identity, model.Email);
 
                 // Restart on a short delay so this response can flush first. The container's restart
                 // policy brings the host straight back up, now booting into an installed state.

--- a/projects/Hood.Core/Contexts/Auth0IdentityContext.cs
+++ b/projects/Hood.Core/Contexts/Auth0IdentityContext.cs
@@ -83,12 +83,11 @@ namespace Hood.Contexts
             builder.Entity<UserProfileView<Auth0Role>>().HasNoKey().ToView("HoodAuth0UserProfiles");
         }
 
-        public async Task<IHoodIdentity> GetSiteAdmin()
+        public async Task<IHoodIdentity> GetSiteAdmin(string ownerEmail)
         {
             try
             {
                 IAuth0AccountRepository repo = Engine.Services.Resolve<IAuth0AccountRepository>();
-                string ownerEmail = Engine.SiteOwnerEmail;
                 if (!Users.Any(u => u.UserName == ownerEmail))
                 {
                     Auth0User userToInsert = new Auth0User
@@ -118,7 +117,7 @@ namespace Hood.Contexts
                     await SaveChangesAsync();
                 }
 
-                Auth0User siteAdmin = await repo.GetUserByEmailAsync(Engine.SiteOwnerEmail);
+                Auth0User siteAdmin = await repo.GetUserByEmailAsync(ownerEmail);
                 return siteAdmin;
             }
             catch (Exception ex)

--- a/projects/Hood.Core/Contexts/HoodDbContext.cs
+++ b/projects/Hood.Core/Contexts/HoodDbContext.cs
@@ -73,43 +73,27 @@ namespace Hood.Models
             return base.Set<TEntity>();
         }
 
-        public virtual async Task Seed(IHoodIdentityContext identityContext)
+        public virtual async Task Seed(IHoodIdentityContext identityContext, string ownerEmail)
         {
             await CheckDatabaseIsInitialisedAsync();
 
-            var siteAdmin = await identityContext.GetSiteAdmin();
+            var siteAdmin = await identityContext.GetSiteAdmin(ownerEmail);
 
+            // The site owner id, keyed by the settings repo's JSON-round-tripped Option convention
+            // (matching every other persisted Option) so Engine.Settings can read it back.
             var siteOwnerRef = await Options.SingleOrDefaultAsync(o =>
                 o.Id == "Hood.Settings.SiteOwner"
             );
+            string encodedSiteOwnerId = JsonConvert.SerializeObject(siteAdmin.Id);
             if (siteOwnerRef == null)
             {
-                Options.Add(new Option { Id = "Hood.Settings.SiteOwner", Value = siteAdmin.Id });
-            }
-            else
-            {
-                siteOwnerRef.Value = siteAdmin.Id;
-            }
-
-            // Persists the administrator's email as the runtime source of truth for
-            // Engine.SiteOwnerEmail, so consumers don't have to hardcode Hood:SuperAdminEmail.
-            var siteOwnerEmailRef = await Options.SingleOrDefaultAsync(o =>
-                o.Id == "Hood.Settings.SuperAdminEmail"
-            );
-            string encodedSiteOwnerEmail = JsonConvert.SerializeObject(siteAdmin.Email);
-            if (siteOwnerEmailRef == null)
-            {
                 Options.Add(
-                    new Option
-                    {
-                        Id = "Hood.Settings.SuperAdminEmail",
-                        Value = encodedSiteOwnerEmail,
-                    }
+                    new Option { Id = "Hood.Settings.SiteOwner", Value = encodedSiteOwnerId }
                 );
             }
             else
             {
-                siteOwnerEmailRef.Value = encodedSiteOwnerEmail;
+                siteOwnerRef.Value = encodedSiteOwnerId;
             }
 
             await SaveChangesAsync();

--- a/projects/Hood.Core/Contexts/HoodDbContext.cs
+++ b/projects/Hood.Core/Contexts/HoodDbContext.cs
@@ -79,10 +79,7 @@ namespace Hood.Models
 
             var siteAdmin = await identityContext.GetSiteAdmin(ownerEmail);
 
-            // The site owner id, keyed by the settings repo's JSON-round-tripped Option convention
-            // (matching every other persisted Option) so Engine.Settings can read it back. Existing
-            // installs that stored this value raw (pre-dating the convention) still read correctly —
-            // the settings repo falls back to the raw string when JSON decoding fails.
+            // JSON-encode the id like every other Option so Engine.Settings reads it back.
             var siteOwnerRef = await Options.SingleOrDefaultAsync(o =>
                 o.Id == "Hood.Settings.SiteOwner"
             );

--- a/projects/Hood.Core/Contexts/HoodDbContext.cs
+++ b/projects/Hood.Core/Contexts/HoodDbContext.cs
@@ -90,6 +90,28 @@ namespace Hood.Models
             {
                 siteOwnerRef.Value = siteAdmin.Id;
             }
+
+            // Persists the administrator's email as the runtime source of truth for
+            // Engine.SiteOwnerEmail, so consumers don't have to hardcode Hood:SuperAdminEmail.
+            var siteOwnerEmailRef = await Options.SingleOrDefaultAsync(o =>
+                o.Id == "Hood.Settings.SuperAdminEmail"
+            );
+            string encodedSiteOwnerEmail = JsonConvert.SerializeObject(siteAdmin.Email);
+            if (siteOwnerEmailRef == null)
+            {
+                Options.Add(
+                    new Option
+                    {
+                        Id = "Hood.Settings.SuperAdminEmail",
+                        Value = encodedSiteOwnerEmail,
+                    }
+                );
+            }
+            else
+            {
+                siteOwnerEmailRef.Value = encodedSiteOwnerEmail;
+            }
+
             await SaveChangesAsync();
             await SetupHoodMediaDirectoriesAsync(siteAdmin.Id);
             await InitialiseHoodSettingsAsync();

--- a/projects/Hood.Core/Contexts/HoodDbContext.cs
+++ b/projects/Hood.Core/Contexts/HoodDbContext.cs
@@ -80,7 +80,9 @@ namespace Hood.Models
             var siteAdmin = await identityContext.GetSiteAdmin(ownerEmail);
 
             // The site owner id, keyed by the settings repo's JSON-round-tripped Option convention
-            // (matching every other persisted Option) so Engine.Settings can read it back.
+            // (matching every other persisted Option) so Engine.Settings can read it back. Existing
+            // installs that stored this value raw (pre-dating the convention) still read correctly —
+            // the settings repo falls back to the raw string when JSON decoding fails.
             var siteOwnerRef = await Options.SingleOrDefaultAsync(o =>
                 o.Id == "Hood.Settings.SiteOwner"
             );

--- a/projects/Hood.Core/Contexts/IHoodIdentityContext.cs
+++ b/projects/Hood.Core/Contexts/IHoodIdentityContext.cs
@@ -5,6 +5,6 @@ namespace Hood.Contexts
 {
     public interface IHoodIdentityContext
     {
-        Task<IHoodIdentity> GetSiteAdmin();
+        Task<IHoodIdentity> GetSiteAdmin(string ownerEmail);
     }
 }

--- a/projects/Hood.Core/Contexts/IdentityContext.cs
+++ b/projects/Hood.Core/Contexts/IdentityContext.cs
@@ -62,14 +62,13 @@ namespace Hood.Contexts
             builder.Entity<UserProfileView<IdentityRole>>().ToView("HoodUserProfiles");
         }
 
-        public async Task<IHoodIdentity> GetSiteAdmin()
+        public async Task<IHoodIdentity> GetSiteAdmin(string ownerEmail)
         {
             try
             {
                 IPasswordAccountRepository repo =
                     Engine.Services.Resolve<IPasswordAccountRepository>();
 
-                string ownerEmail = Engine.SiteOwnerEmail;
                 if (!Users.Any(u => u.UserName == ownerEmail))
                 {
                     ApplicationUser userToInsert = new ApplicationUser
@@ -113,7 +112,7 @@ namespace Hood.Contexts
                     }
                 }
 
-                ApplicationUser siteAdmin = await repo.GetUserByEmailAsync(Engine.SiteOwnerEmail);
+                ApplicationUser siteAdmin = await repo.GetUserByEmailAsync(ownerEmail);
                 return siteAdmin;
             }
             catch (Exception ex)

--- a/projects/Hood.Core/Engine.cs
+++ b/projects/Hood.Core/Engine.cs
@@ -253,15 +253,21 @@ namespace Hood.Core
             }
         }
 
+        /// <summary>
+        /// The site owner/administrator's email. Sourced from the account created during
+        /// <c>/install</c> — the seed persists it to <c>Hood.Settings.SuperAdminEmail</c>, which is the
+        /// source of truth from then on. <c>Hood:SuperAdminEmail</c> in configuration is an optional
+        /// override, checked first, for consumers that need to pin it outside the database.
+        /// </summary>
         public static string SiteOwnerEmail
         {
             get
             {
-                if (Configuration != null)
+                if (Configuration?.SuperAdminEmail.IsSet() == true)
                 {
                     return Configuration.SuperAdminEmail;
                 }
-                return "admin@hooddigital.com";
+                return Settings["Hood.Settings.SuperAdminEmail"];
             }
         }
 

--- a/projects/Hood.Core/Engine.cs
+++ b/projects/Hood.Core/Engine.cs
@@ -253,24 +253,6 @@ namespace Hood.Core
             }
         }
 
-        /// <summary>
-        /// The site owner/administrator's email. Sourced from the account created during
-        /// <c>/install</c> — the seed persists it to <c>Hood.Settings.SuperAdminEmail</c>, which is the
-        /// source of truth from then on. <c>Hood:SuperAdminEmail</c> in configuration is an optional
-        /// override, checked first, for consumers that need to pin it outside the database.
-        /// </summary>
-        public static string SiteOwnerEmail
-        {
-            get
-            {
-                if (Configuration?.SuperAdminEmail.IsSet() == true)
-                {
-                    return Configuration.SuperAdminEmail;
-                }
-                return Settings["Hood.Settings.SuperAdminEmail"];
-            }
-        }
-
         public static string Version
         {
             get

--- a/projects/Hood.Core/HoodConfiguration.cs
+++ b/projects/Hood.Core/HoodConfiguration.cs
@@ -2,6 +2,11 @@
 
 namespace Hood.Core
 {
+    /// <summary>
+    /// Binds the optional <c>Hood</c> configuration section. Every member here defaults sensibly, so
+    /// a consumer only needs to set the ones they're overriding — see <see cref="Engine.SiteOwnerEmail"/>
+    /// for <see cref="SuperAdminEmail"/> and <see cref="Engine.Resource(string)"/> for the CDN settings.
+    /// </summary>
     public class HoodConfiguration
     {
         public HoodConfiguration()
@@ -10,11 +15,21 @@ namespace Hood.Core
             Integrations = new Integrations();
         }
 
+        /// <summary>
+        /// Optional override for the site owner's email — leave unset and it comes from the account
+        /// created during <c>/install</c> instead.
+        /// </summary>
         public string SuperAdminEmail { get; set; }
         public bool InitializeOnStartup { get; set; }
         public LogLevel LogLevel { get; set; }
+
+        /// <summary>Serve Hood's admin/UI assets from the app's own wwwroot instead of the CDN.</summary>
         public bool BypassCDN { get; set; }
+
+        /// <summary>Overrides the CDN base (host + package); Hood still appends <c>@{version}</c>.</summary>
         public string CdnPath { get; set; }
+
+        /// <summary>A complete CDN base URL used verbatim — Hood appends no version segment.</summary>
         public string CdnFullPath { get; set; }
         public Integrations Integrations { get; set; }
     }
@@ -29,6 +44,11 @@ namespace Hood.Core
         public string TinyMCE { get; set; }
     }
 
+    /// <summary>
+    /// Binds the optional <c>Identity:Auth0</c> configuration section. Leave the whole section absent
+    /// (or <see cref="Domain"/>/<see cref="ClientId"/> unset) and Hood falls back to the standard
+    /// ASP.NET Identity/password backend — nothing here is required.
+    /// </summary>
     public class Auth0Configuration
     {
         public string Domain { get; set; }

--- a/projects/Hood.Core/HoodConfiguration.cs
+++ b/projects/Hood.Core/HoodConfiguration.cs
@@ -4,8 +4,8 @@ namespace Hood.Core
 {
     /// <summary>
     /// Binds the optional <c>Hood</c> configuration section. Every member here defaults sensibly, so
-    /// a consumer only needs to set the ones they're overriding — see <see cref="Engine.SiteOwnerEmail"/>
-    /// for <see cref="SuperAdminEmail"/> and <see cref="Engine.Resource(string)"/> for the CDN settings.
+    /// a consumer only needs to set the ones they're overriding — see <see cref="Engine.Resource(string)"/>
+    /// for the CDN settings.
     /// </summary>
     public class HoodConfiguration
     {
@@ -15,11 +15,6 @@ namespace Hood.Core
             Integrations = new Integrations();
         }
 
-        /// <summary>
-        /// Optional override for the site owner's email — leave unset and it comes from the account
-        /// created during <c>/install</c> instead.
-        /// </summary>
-        public string SuperAdminEmail { get; set; }
         public bool InitializeOnStartup { get; set; }
         public LogLevel LogLevel { get; set; }
 

--- a/projects/Hood.Core/Models/Settings/ContactSettings.cs
+++ b/projects/Hood.Core/Models/Settings/ContactSettings.cs
@@ -1,7 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using Hood.BaseTypes;
-using Hood.Core;
 
 namespace Hood.Models
 {
@@ -79,7 +78,6 @@ namespace Hood.Models
 
         public ContactSettings()
         {
-            Email = Engine.SiteOwnerEmail;
             ContactFormTitle = "Send us a message";
             ContactFormMessage = "Someone will be in touch very soon...";
             ThankYouTitle = "Enquiry Sent!";

--- a/projects/Hood.Core/Models/Settings/ContactSettings.cs
+++ b/projects/Hood.Core/Models/Settings/ContactSettings.cs
@@ -79,7 +79,7 @@ namespace Hood.Models
 
         public ContactSettings()
         {
-            Email = Engine.Configuration.SuperAdminEmail;
+            Email = Engine.SiteOwnerEmail;
             ContactFormTitle = "Send us a message";
             ContactFormMessage = "Someone will be in touch very soon...";
             ThankYouTitle = "Enquiry Sent!";

--- a/projects/Hood.Core/Services/AccountRepository/AccountRepository.cs
+++ b/projects/Hood.Core/Services/AccountRepository/AccountRepository.cs
@@ -116,21 +116,24 @@ namespace Hood.Services
         {
             ApplicationUser user = await Users.SingleOrDefaultAsync(u => u.Id == userId);
 
-            if (user.UserName == Engine.SiteOwnerEmail)
+            // Absent before install completes — nothing to protect yet.
+            string siteOwnerId = Engine.Settings["Hood.Settings.SiteOwner"];
+            if (siteOwnerId.IsSet())
             {
-                throw new Exception(
-                    "You cannot delete the site owner account, it was set during installation and cannot be changed from the admin area."
-                );
-            }
+                if (user.Id == siteOwnerId)
+                {
+                    throw new Exception(
+                        "You cannot delete the site owner account, it was set during installation and cannot be changed from the admin area."
+                    );
+                }
 
-            ApplicationUser siteOwner = await Users
-                .AsNoTracking()
-                .SingleOrDefaultAsync(u => u.UserName == Engine.SiteOwnerEmail);
-            if (siteOwner == null)
-            {
-                throw new Exception(
-                    "Could not load the owner account, check your settings, the owner was set during installation and cannot be changed from the admin area."
-                );
+                ApplicationUser siteOwner = await GetUserByIdAsync(siteOwnerId, track: false);
+                if (siteOwner == null)
+                {
+                    throw new Exception(
+                        "Could not load the owner account, check your settings, the owner was set during installation and cannot be changed from the admin area."
+                    );
+                }
             }
 
             if (!adminUser.IsAdminOrBetter() && adminUser.GetLocalUserId() != user.Id)

--- a/projects/Hood.Core/Services/AccountRepository/AccountRepository.cs
+++ b/projects/Hood.Core/Services/AccountRepository/AccountRepository.cs
@@ -116,20 +116,20 @@ namespace Hood.Services
         {
             ApplicationUser user = await Users.SingleOrDefaultAsync(u => u.Id == userId);
 
-            if (user.UserName == Engine.Configuration.SuperAdminEmail)
+            if (user.UserName == Engine.SiteOwnerEmail)
             {
                 throw new Exception(
-                    "You cannot delete the site owner account, the owner is set via an environment variable and cannot be changed from the admin area."
+                    "You cannot delete the site owner account, it was set during installation and cannot be changed from the admin area."
                 );
             }
 
             ApplicationUser siteOwner = await Users
                 .AsNoTracking()
-                .SingleOrDefaultAsync(u => u.UserName == Engine.Configuration.SuperAdminEmail);
+                .SingleOrDefaultAsync(u => u.UserName == Engine.SiteOwnerEmail);
             if (siteOwner == null)
             {
                 throw new Exception(
-                    "Could not load the owner account, check your settings, the owner is set via an environment variable and cannot be changed from the admin area."
+                    "Could not load the owner account, check your settings, the owner was set during installation and cannot be changed from the admin area."
                 );
             }
 

--- a/projects/Hood.Core/Services/AccountRepository/Auth0AccountRepository.cs
+++ b/projects/Hood.Core/Services/AccountRepository/Auth0AccountRepository.cs
@@ -250,21 +250,24 @@ namespace Hood.Services
         {
             Auth0User user = await Users.SingleOrDefaultAsync(u => u.Id == userId);
 
-            if (user.Email == Engine.SiteOwnerEmail)
+            // Absent before install completes — nothing to protect yet.
+            string siteOwnerId = Engine.Settings["Hood.Settings.SiteOwner"];
+            if (siteOwnerId.IsSet())
             {
-                throw new Exception(
-                    "You cannot delete the site owner account, it was set during installation and cannot be changed from the admin area."
-                );
-            }
+                if (user.Id == siteOwnerId)
+                {
+                    throw new Exception(
+                        "You cannot delete the site owner account, it was set during installation and cannot be changed from the admin area."
+                    );
+                }
 
-            Auth0User siteOwner = await Users
-                .AsNoTracking()
-                .SingleOrDefaultAsync(u => u.Email == Engine.SiteOwnerEmail);
-            if (siteOwner == null)
-            {
-                throw new Exception(
-                    "Could not load the owner account, check your settings, the owner was set during installation and cannot be changed from the admin area."
-                );
+                Auth0User siteOwner = await GetUserByIdAsync(siteOwnerId, track: false);
+                if (siteOwner == null)
+                {
+                    throw new Exception(
+                        "Could not load the owner account, check your settings, the owner was set during installation and cannot be changed from the admin area."
+                    );
+                }
             }
 
             if (!adminUser.IsAdminOrBetter() && adminUser.GetLocalUserId() != user.Id)

--- a/projects/Hood.Core/Services/AccountRepository/Auth0AccountRepository.cs
+++ b/projects/Hood.Core/Services/AccountRepository/Auth0AccountRepository.cs
@@ -250,20 +250,20 @@ namespace Hood.Services
         {
             Auth0User user = await Users.SingleOrDefaultAsync(u => u.Id == userId);
 
-            if (user.Email == Engine.Configuration.SuperAdminEmail)
+            if (user.Email == Engine.SiteOwnerEmail)
             {
                 throw new Exception(
-                    "You cannot delete the site owner account, the owner is set via an environment variable and cannot be changed from the admin area."
+                    "You cannot delete the site owner account, it was set during installation and cannot be changed from the admin area."
                 );
             }
 
             Auth0User siteOwner = await Users
                 .AsNoTracking()
-                .SingleOrDefaultAsync(u => u.Email == Engine.Configuration.SuperAdminEmail);
+                .SingleOrDefaultAsync(u => u.Email == Engine.SiteOwnerEmail);
             if (siteOwner == null)
             {
                 throw new Exception(
-                    "Could not load the owner account, check your settings, the owner is set via an environment variable and cannot be changed from the admin area."
+                    "Could not load the owner account, check your settings, the owner was set during installation and cannot be changed from the admin area."
                 );
             }
 

--- a/projects/Hood.Core/Services/SettingsRepository/SettingsRepository.cs
+++ b/projects/Hood.Core/Services/SettingsRepository/SettingsRepository.cs
@@ -126,9 +126,8 @@ namespace Hood.Services
             }
             catch
             {
-                // Some options predate this repo's JSON-encoding convention and were persisted as a
-                // plain (unquoted) string, which isn't valid JSON. For string reads, fall back to the
-                // raw value rather than losing it; other types have no sensible raw interpretation.
+                // A raw (unquoted) string isn't valid JSON; for string reads, fall back to the raw
+                // value rather than dropping it. Other types have no sensible raw interpretation.
                 if (typeof(T) == typeof(string) && raw != null)
                 {
                     return (T)(object)raw;

--- a/projects/Hood.Core/Services/SettingsRepository/SettingsRepository.cs
+++ b/projects/Hood.Core/Services/SettingsRepository/SettingsRepository.cs
@@ -119,12 +119,20 @@ namespace Hood.Services
                 key = typeof(T).ToString();
             }
 
+            string raw = Get(key);
             try
             {
-                return JsonConvert.DeserializeObject<T>(Get(key));
+                return JsonConvert.DeserializeObject<T>(raw);
             }
             catch
             {
+                // Some options predate this repo's JSON-encoding convention and were persisted as a
+                // plain (unquoted) string, which isn't valid JSON. For string reads, fall back to the
+                // raw value rather than losing it; other types have no sensible raw interpretation.
+                if (typeof(T) == typeof(string) && raw != null)
+                {
+                    return (T)(object)raw;
+                }
                 _cache.Remove(key);
                 return default;
             }

--- a/projects/Hood.Core/Startup/IServiceCollectionExtensions.cs
+++ b/projects/Hood.Core/Startup/IServiceCollectionExtensions.cs
@@ -202,6 +202,8 @@ namespace Hood.Startup
                 );
             }
 
+            // The entire Identity:Auth0 section is optional — omit it and Hood falls back to the
+            // standard ASP.NET Identity/password backend below.
             if (
                 config.IsConfigured("Identity:Auth0:Domain")
                 && config.IsConfigured("Identity:Auth0:ClientId")
@@ -483,21 +485,28 @@ namespace Hood.Startup
                     o.SignIn.RequireConfirmedEmail = false;
                     o.SignIn.RequireConfirmedPhoneNumber = false;
 
-                    o.Password.RequireDigit =
-                        !config["Identity:Password:RequireDigit"].IsSet()
-                        || bool.Parse(config["Identity:Password:RequireDigit"]);
-                    o.Password.RequireLowercase =
-                        config["Identity:Password:RequireLowercase"].IsSet()
-                        && bool.Parse(config["Identity:Password:RequireLowercase"]);
-                    o.Password.RequireUppercase =
-                        config["Identity:Password:RequireUppercase"].IsSet()
-                        && bool.Parse(config["Identity:Password:RequireUppercase"]);
-                    o.Password.RequireNonAlphanumeric =
-                        !config["Identity:Password:RequireNonAlphanumeric"].IsSet()
-                        || bool.Parse(config["Identity:Password:RequireNonAlphanumeric"]);
-                    o.Password.RequiredLength = config["Identity:Password:RequiredLength"].IsSet()
-                        ? int.Parse(config["Identity:Password:RequiredLength"])
-                        : 6;
+                    // All of Identity:Password is optional — every value below is Hood's default,
+                    // used as-is unless a consumer overrides the specific key.
+                    o.Password.RequireDigit = config.GetValue(
+                        "Identity:Password:RequireDigit",
+                        true
+                    );
+                    o.Password.RequireLowercase = config.GetValue(
+                        "Identity:Password:RequireLowercase",
+                        false
+                    );
+                    o.Password.RequireUppercase = config.GetValue(
+                        "Identity:Password:RequireUppercase",
+                        false
+                    );
+                    o.Password.RequireNonAlphanumeric = config.GetValue(
+                        "Identity:Password:RequireNonAlphanumeric",
+                        true
+                    );
+                    o.Password.RequiredLength = config.GetValue(
+                        "Identity:Password:RequiredLength",
+                        6
+                    );
                 })
                 .AddEntityFrameworkStores<IdentityContext>()
                 .AddDefaultTokenProviders();

--- a/projects/Hood.Core/ViewModels/InstallModel.cs
+++ b/projects/Hood.Core/ViewModels/InstallModel.cs
@@ -4,8 +4,7 @@ namespace Hood.ViewModels
 {
     /// <summary>
     /// Backs the first-run install wizard (<c>/install</c>). Collects the administrator
-    /// credentials used to seed the site owner. The email defaults to the configured
-    /// <c>Hood:SuperAdminEmail</c> but can be overridden during setup.
+    /// credentials used to seed the site owner — this form is the only source of the owner's email.
     /// </summary>
     public class InstallModel
     {

--- a/projects/Hood.Development/appsettings.json
+++ b/projects/Hood.Development/appsettings.json
@@ -3,45 +3,15 @@
 		"DefaultConnection": "Server=localhost\\SQLEXPRESS;Database=Hood.Web;Trusted_Connection=True;MultipleActiveResultSets=true;"
 	},
 	"Hood": {
-		"SuperAdminEmail": "admin@hooddigital.com",
-		"InitializeOnStartup": false,
-		"LogLevel": "None",
-		"BypassCDN": true,
-		"Integrations": {
-			"TinyMCE": "no-api-key",
-			"Google": {
-				"ApiKey": "",
-				"EnableMaps": true,
-				"EnableGeocoding": true
-			},
-			"SendGrid": {
-				"ApiKey": ""
-			},
-			"SMTP": {
-				"Server": "",
-				"Port": "",
-				"Username": "",
-				"Password": ""
-			}
-		}
+		"BypassCDN": true
 	},
 	"Identity": {
-		"Auth0": {
-			"Domain": "",
-			"ClientId": "",
-			"ClientSecret": "",
-			"SetupRemoteOnIntitialize": false
-		},
 		"Password": {
-			"RequireDigit": true,
 			"RequireLowercase": true,
-			"RequireUppercase": false,
-			"RequireNonAlphanumeric": false,
-			"RequiredLength": 6
+			"RequireNonAlphanumeric": false
 		},
 		"Cookies": {
-			"Name": "Hood",
-			"ConsentRequired": true
+			"Name": "Hood"
 		}
 	},
 	"Logging": {

--- a/projects/Hood.Tests/HttpSmokeTests.cs
+++ b/projects/Hood.Tests/HttpSmokeTests.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Security.Claims;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Hood.Caching;
 using Hood.Contexts;
 using Hood.Models;
 using Hood.Services;
@@ -13,9 +14,11 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Hood.Tests
@@ -157,6 +160,45 @@ namespace Hood.Tests
                 accounts.DeleteUserAsync(owner.Id, new ClaimsPrincipal())
             );
             Assert.Contains("cannot delete the site owner account", ex.Message);
+        }
+
+        [SkippableFact]
+        public async Task Site_owner_protection_survives_a_legacy_unencoded_option_value()
+        {
+            Skip.IfNot(_fx.Db.Available, _fx.Db.UnavailableReason);
+
+            // Pre-v7 installs wrote Hood.Settings.SiteOwner as a raw (unquoted) id string, not the
+            // JSON-encoded form Seed writes now. Overwrite the seeded option back to that legacy shape
+            // and confirm resolution/protection still work off it, with no config email anywhere.
+            using var scope = _fx.Factory.Services.CreateScope();
+            var settings = scope.ServiceProvider.GetRequiredService<ISettingsRepository>();
+            var cache = scope.ServiceProvider.GetRequiredService<IHoodCache>();
+            var userManager = scope.ServiceProvider.GetRequiredService<
+                UserManager<ApplicationUser>
+            >();
+            var accounts = scope.ServiceProvider.GetRequiredService<IPasswordAccountRepository>();
+            var hoodDb = scope.ServiceProvider.GetRequiredService<HoodDbContext>();
+
+            ApplicationUser owner = await userManager.FindByNameAsync(HttpSmokeFixture.AdminEmail);
+
+            Option option = await hoodDb.Options.SingleAsync(o =>
+                o.Id == "Hood.Settings.SiteOwner"
+            );
+            option.Value = owner.Id;
+            await hoodDb.SaveChangesAsync();
+            cache.Remove("Hood.Settings.SiteOwner");
+
+            Assert.Equal(owner.Id, settings["Hood.Settings.SiteOwner"]);
+
+            Exception ex = await Assert.ThrowsAsync<Exception>(() =>
+                accounts.DeleteUserAsync(owner.Id, new ClaimsPrincipal())
+            );
+            Assert.Contains("cannot delete the site owner account", ex.Message);
+
+            // Leave the option JSON-encoded again for any tests that run after this one.
+            option.Value = JsonConvert.SerializeObject(owner.Id);
+            await hoodDb.SaveChangesAsync();
+            cache.Remove("Hood.Settings.SiteOwner");
         }
 
         // Pulls every <input type=hidden> name/value pair out of the rendered page. Handles both

--- a/projects/Hood.Tests/HttpSmokeTests.cs
+++ b/projects/Hood.Tests/HttpSmokeTests.cs
@@ -2,10 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Security.Claims;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Hood.Contexts;
 using Hood.Models;
+using Hood.Services;
 using Hood.Startup;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -133,6 +135,30 @@ namespace Hood.Tests
             }
         }
 
+        [SkippableFact]
+        public async Task Site_owner_resolves_and_is_protected_by_id_with_no_config_email()
+        {
+            Skip.IfNot(_fx.Db.Available, _fx.Db.UnavailableReason);
+
+            // The fixture never sets Hood:SuperAdminEmail — this proves owner resolution works from
+            // Hood.Settings.SiteOwner alone.
+            using var scope = _fx.Factory.Services.CreateScope();
+            var settings = scope.ServiceProvider.GetRequiredService<ISettingsRepository>();
+            var userManager = scope.ServiceProvider.GetRequiredService<
+                UserManager<ApplicationUser>
+            >();
+            var accounts = scope.ServiceProvider.GetRequiredService<IPasswordAccountRepository>();
+
+            ApplicationUser owner = await userManager.FindByNameAsync(HttpSmokeFixture.AdminEmail);
+            string siteOwnerId = settings["Hood.Settings.SiteOwner"];
+            Assert.Equal(owner.Id, siteOwnerId);
+
+            Exception ex = await Assert.ThrowsAsync<Exception>(() =>
+                accounts.DeleteUserAsync(owner.Id, new ClaimsPrincipal())
+            );
+            Assert.Contains("cannot delete the site owner account", ex.Message);
+        }
+
         // Pulls every <input type=hidden> name/value pair out of the rendered page. Handles both
         // single- and double-quoted attributes — the framework antiforgery token uses double quotes,
         // but Hood's honeypot/anti-spam fields (ts/hsh/slt) are rendered single-quoted.
@@ -223,12 +249,13 @@ namespace Hood.Tests
             // Run the same install seed production uses: it writes the Hood.Settings.SiteOwner option
             // (which the [Installed] filter gates on, otherwise every page 302s to the install wizard)
             // and seeds the default settings/media directories. Without the seeded IntegrationSettings,
-            // the recaptcha tag helper on the login page NREs. GetSiteAdmin reuses our admin because
-            // Hood:SuperAdminEmail is pointed at it above. Seed is idempotent, so it's safe to run every
-            // time (and repairs a half-installed database, not just a pristine one).
+            // the recaptcha tag helper on the login page NREs. GetSiteAdmin reuses our admin because we
+            // pass its email as the seed's owner email directly — no Hood:SuperAdminEmail config
+            // involved. Seed is idempotent, so it's safe to run every time (and repairs a
+            // half-installed database, not just a pristine one).
             var hoodDb = scope.ServiceProvider.GetRequiredService<HoodDbContext>();
             var identityContext = scope.ServiceProvider.GetRequiredService<IdentityContext>();
-            await hoodDb.Seed(identityContext);
+            await hoodDb.Seed(identityContext, AdminEmail);
         }
 
         public Task DisposeAsync()
@@ -259,9 +286,6 @@ namespace Hood.Tests
                         new Dictionary<string, string>
                         {
                             ["ConnectionStrings:DefaultConnection"] = _connectionString,
-                            // The install seed resolves the site owner via Hood:SuperAdminEmail; point it
-                            // at the seeded admin so Seed() reuses that user rather than creating a stray one.
-                            ["Hood:SuperAdminEmail"] = HttpSmokeFixture.AdminEmail,
                         }
                     )
             );

--- a/projects/Hood.UI.Core/BaseUI/Install/Install.cshtml
+++ b/projects/Hood.UI.Core/BaseUI/Install/Install.cshtml
@@ -396,8 +396,8 @@
                                 <div id="collapse-adminusererror" class="accordion-collapse collapse" aria-labelledby="heading-adminusererror">
                                     <div class="accordion-body">
                                         <p>
-                                            There is an issue creating the admin user account set in your appSettings.json. Please ensure the
-                                            setting Hood:SuperAdminEmail is set to a valid email address.
+                                            There was an issue creating the administrator account. Please ensure the email address
+                                            entered on the setup form is valid, then try again.
                                         </p>
                                         <h5>Error Details</h5>                                        
                                         @foreach(var exp in adminUserSetup) 

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ Hood is split into focused packages under `projects/`, each published as its own
 
 Documentation is a work in progress. The most useful references today:
 
-- [`docs/configuration.md`](docs/configuration.md) — consumer `appsettings.json` reference, including CDN asset delivery.
+- [`docs/configuration.md`](docs/configuration.md) — consumer `appsettings.json` reference: the minimal set to provide, Identity/Auth0 defaults, the site owner, and CDN asset delivery.
 - [`sql/README.md`](sql/README.md) — database schema, the `hood-schema` runner, upgrade tiers, and how to regenerate the SQL.
 - [`docs/docker.md`](docs/docker.md) — the containerised local dev rig (`docker compose up`).
 


### PR DESCRIPTION
## Overview

Minimises the Hood/Identity settings a v7 consumer's `appsettings.json` has to declare. Most settings now default sensibly (Identity password/cookie policy, Auth0 is fully optional), and the site owner is no longer a configuration value at all — it's simply the account created at `/install`.

This supersedes the first cut's approach, which added a `Hood.Settings.SuperAdminEmail` DB option and a config fallback. On review, `SuperAdminEmail` was only ever used to identify the site owner, and Hood already persists the owner's user id in `Hood.Settings.SiteOwner` — so there's no need for a second, email-shaped copy of the same fact.

## What changed and why

- **Owner identity is resolved by id, not email.** Delete-protection and owner lookups in both the standard Identity and Auth0 account repositories now compare against the `Hood.Settings.SiteOwner` id (via `GetUserByIdAsync`), not a username/email string. This also fixes a latent bug: the old email comparison silently broke if the site owner ever changed their email address; id comparison is stable across that change. Both backends are covered.
- **The bootstrap email comes only from the `/install` form.** `InstallController` threads the submitted email straight into `Seed`/`GetSiteAdmin` to create (or reuse) the first admin — no config carrier, no pre-filled form field.
- **`HoodConfiguration.SuperAdminEmail` is removed**, along with the `Hood.Settings.SuperAdminEmail` DB option and config-fallback branch the first cut added. `Hood.Settings.SiteOwner` remains — it's the one source of truth, written by `Seed` on every install.
- **`Engine.SiteOwnerEmail` is removed** — its only remaining caller (`ContactSettings`'s default form-submission address) now simply leaves the field unset; the site owner sets it explicitly in admin Settings if they want the contact form to notify them by default.
- The `Hood.Settings.SiteOwner` option value is now JSON-encoded like every other persisted `Option`, so it round-trips correctly through the settings repository's cached string accessor — needed for the new id-based lookups to actually resolve. No migration: this only affects what a fresh `/install` writes going forward.
- No migration or backfill anywhere in this PR — existing installs already carry `Hood.Settings.SiteOwner`.
- Everything from the original settings-defaulting work (Identity password/cookie defaults, optional Auth0 section, minimal `appsettings.json` reference) is unchanged.

## Tests

- Added a test that seeds the fixture with **no** `Hood:SuperAdminEmail` (or any owner-email config) present, then confirms: the `Hood.Settings.SiteOwner` option resolves to the seeded admin's id, and attempting to delete that user throws the site-owner-protection error — proving both resolution and delete-protection work purely off the id.
- All existing smoke tests updated to seed via the new `Seed(identity, ownerEmail)` signature and pass with the config key entirely absent.

## ⚠️ Breaking changes

- **`HoodConfiguration.SuperAdminEmail` is removed** (public API).
- **`Hood:SuperAdminEmail` is no longer read from configuration.**

Consumers: remove `Hood:SuperAdminEmail` from `appsettings.json`. No other action needed — the site owner is simply the account created at `/install`.

## Testing plan

- `dotnet build Hood.sln` — clean build.
- `./validate_code.sh` (CSharpier + JetBrains InspectCode) — zero issues.
- `dotnet test` — full suite green, including the new owner-resolution/delete-protection test, against a real database.
