### PR TITLE
HOOD-136 - Add Renovate config and retire Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  # Keep the SHA-pinned GitHub Actions current (Dependabot updates the pin + the version comment).
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "mode": "full",
+  "dependencyDashboard": true,
+  "configMigration": true,
+  "semanticCommits": "disabled",
+  "commitMessageTopic": "{{depName}}",
+  "labels": ["dependencies"],
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 2,
+  "major": {
+    "dependencyDashboardApproval": true
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["dependencies", "security"]
+  },
+  "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "groupName": ".NET runtime",
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["/^Microsoft\\.AspNetCore\\./", "/^Microsoft\\.Extensions\\./"]
+    },
+    {
+      "groupName": ".NET runtime",
+      "matchDepNames": ["dotnet-sdk"]
+    },
+    {
+      "groupName": "Test and build tooling",
+      "matchPackageNames": ["/^xunit/", "Microsoft.NET.Test.Sdk", "Xunit.SkippableFact", "/csharpier/i", "/resharper/i", "/jetbrains/i"]
+    },
+    {
+      "groupName": "Auth0",
+      "matchPackageNames": ["/^Auth0\\./"]
+    },
+    {
+      "groupName": "Azure",
+      "matchPackageNames": ["/^Azure\\./"]
+    },
+    {
+      "groupName": "GitHub Actions",
+      "matchManagers": ["github-actions"]
+    },
+    {
+      "groupName": "JavaScript toolchain",
+      "matchManagers": ["npm"]
+    }
+  ],
+  "prBodyTemplate": "## Overview\n\n{{{table}}}\n\n## What Changed and Why\n\nRoutine dependency currency — always latest stable, aged at least 3 days before raising.\n\n{{{notes}}}\n{{{changelogs}}}\n\n## Tests\n\nAutomated — CI (Validate code, Build & test) gates this change; no source changes beyond the dependency.\n\n## Breaking Changes\n\n{{#if isMajor}}⚠️ Major version update — review the release notes above before merging.{{else}}None.{{/if}}\n\n## Testing Plan\n\n- [ ] CI green\n- [ ] Release notes reviewed\n- [ ] Bedded in (routine) / triaged (security)\n\n{{{controls}}}\n{{{footer}}}"
+}


### PR DESCRIPTION
## Overview

Stands up Renovate (the free Mend-hosted GitHub App) to keep dependencies current — always latest stable, safely — across npm/pnpm, NuGet, the .NET SDK, and GitHub Actions, and retires Dependabot version updates.

## What Changed and Why

**Add `renovate.json`** — covers npm + the `packageManager` (pnpm) + NuGet + the .NET SDK (`global.json`) + GitHub Actions.

- **No auto-merge** — every bump is a manually reviewed PR.
- **Grouped** — `.NET runtime`, `Test and build tooling`, `Auth0`, `Azure`, `GitHub Actions`, `JavaScript toolchain`; everything else individual.
- **Majors park** on the Dependency Dashboard for approval; routine patch/minor flow as PRs.
- **Bedding-in** — a 3-day `minimumReleaseAge` holds a routine update before it's raised, guarding against freshly-published compromised or broken releases.
- **CVEs raise immediately** (labelled `security`, sourced from the GitHub Advisory DB *and* OSV) but merge only after triage.
- **House-style PRs** — `semanticCommits` disabled (no `chore()`, no colons); sentence-case titles; body follows the standard Overview / What Changed / Tests / Breaking Changes / Testing Plan shape.
- `mode: "full"` so Renovate leaves the initial silent/onboarding state and starts raising PRs once this merges.

**Remove `.github/dependabot.yml`** — Renovate now owns version updates across all ecosystems. GitHub Dependabot security *alerts* remain enabled and feed Renovate's `vulnerabilityAlerts`.

## Tests

Configuration only — validated with `renovate-config-validator` (passes). No source or build changes.

## Breaking Changes

None.

## Testing Plan

- [ ] On merge, Renovate leaves silent mode and updates the Dependency Dashboard
- [ ] First routine grouped PR(s) appear after the 3-day bedding-in window
- [ ] Grouping matches intent — tune the `packageRules` regex if a dependency lands ungrouped
